### PR TITLE
[19][21] Implement and write unit test for get job by castingId

### DIFF
--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -28,12 +28,13 @@ export class JobController {
   constructor(private readonly jobService: JobService) {}
 
   @Get()
+  @UseAuthGuard()
   @ApiOperation({ summary: 'get all jobs with filter' })
   @ApiOkResponse({ type: GetJobCardWithMaxPageDto, isArray: true })
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiBadRequestResponse({ description: 'Wrong format' })
-  findAll(@Query() searchJobDto: SearchJobDto) {
-    return this.jobService.findAll(searchJobDto)
+  findAll(@Query() searchJobDto: SearchJobDto, @User() user: JwtDto) {
+    return this.jobService.findAll(searchJobDto, user)
   }
 
   @Get(':id')

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -102,9 +102,27 @@ describe('JobService', () => {
     }
   }) //end it
 
-  //TODO: this is draft findAll only include filtered by castingId test, need more refactor from above
   describe('findAll', () => {
-    const MOCK_CASTING_ID = 30
+    const MOCK_CASTING_ID = 22
+
+    describe('Forbidden casting search', () => {
+      //input request params
+      const reqParams: SearchJobDto = {
+        limit: 1,
+        page: 1,
+        castingId: 1,
+      }
+      //mock user
+      const MOCK_USER = {
+        userId: MOCK_CASTING_ID,
+        type: UserType.CASTING,
+      }
+      it('should throw not forbidden exception', async () => {
+        await expect(service.findAll(reqParams, MOCK_USER)).rejects.toThrow(
+          ForbiddenException,
+        )
+      })
+    })
 
     const jobDataLength = 50 //fixed mock data length in repository
     const itMockedJobData = Array.from({ length: jobDataLength }, (v, i) => {
@@ -137,9 +155,13 @@ describe('JobService', () => {
         }
 
         //mock user
-        const MOCK_USER = {
+        const MOCK_USER_CASTING = {
           userId: MOCK_CASTING_ID,
           type: UserType.CASTING,
+        }
+        const MOCK_USER_ACTOR = {
+          userId: 1,
+          type: UserType.ACTOR,
         }
 
         //mock the repository
@@ -156,9 +178,12 @@ describe('JobService', () => {
           )
 
         //check all property
-        await expect(service.findAll(reqParams, MOCK_USER)).resolves.toEqual(
-          result,
-        )
+        await expect(
+          service.findAll(reqParams, MOCK_USER_CASTING),
+        ).resolves.toEqual(result)
+        await expect(
+          service.findAll(reqParams, MOCK_USER_ACTOR),
+        ).resolves.toEqual(result)
 
         //check repository called with correct params
         const prismaParams = {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -51,10 +51,17 @@ export class JobService {
     }
     return params
   }
-  async findAll(searchJobDto: SearchJobDto) {
+  async findAll(searchJobDto: SearchJobDto, user: JwtDto) {
     //set Default value for limit and page
     searchJobDto.limit = searchJobDto.limit || 20
     searchJobDto.page = searchJobDto.page || 1
+
+    //check if castingId is not equal to user.userId
+    if (user.type == UserType.CASTING) {
+      if (searchJobDto.castingId == undefined)
+        searchJobDto.castingId = user.userId
+      if (searchJobDto.castingId != user.userId) throw new ForbiddenException()
+    }
 
     //set params for getJob
     const params = this.convertRequestToParams(searchJobDto)
@@ -65,7 +72,7 @@ export class JobService {
     result.jobs = jobsJoinCasting
 
     //calculate maxPage
-    //TODO: will calculate maxPage with filter later [19][24]
+    //TODO: will calculate maxPage with filter later [24]
     const allJobsCount = await this.repository.getJobCount({
       where: params.where,
     })

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -45,7 +45,6 @@ export class JobService {
         //status: searchJobDto.status || undefined,
         //gender: searchJobDto.gender || undefined,
 
-        //TODO: Draft for filtering castingId task [19]
         castingId: Number(searchJobDto.castingId) || undefined,
       },
     }

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -18,6 +18,8 @@ export class JobService {
     return 'This action adds a new job'
   }
 
+  // @function create prisma params from request
+  // @helper for findAll function
   convertRequestToParams(searchJobDto: SearchJobDto) {
     const params = {
       //take and skip from limit and page
@@ -64,7 +66,9 @@ export class JobService {
 
     //calculate maxPage
     //TODO: will calculate maxPage with filter later [19][24]
-    const allJobsCount = await this.repository.getJobCount({})
+    const allJobsCount = await this.repository.getJobCount({
+      where: params.where,
+    })
     result.maxPage = Math.ceil(allJobsCount / searchJobDto.limit)
 
     //return jobs


### PR DESCRIPTION
## What did you do
- implement the ```GET job/```  with ```castingId``` params
- write unit test for ```GET job/``` with ```castingId``` params with user type ```actor``` and ```casting```

## Demo
- https://api-dev.modela.miello.dev/swagger#/job/JobController_findAll
- login at ```POST auth/login``` with username: ```ayame@hololive.com```, password: ```ayame123```
- try ```GET job/``` with limit:1 (for easier count total job card by maxPage) , page:1 , castingId: from 20 to 30 (the mocked database have jobs's castingId within this range)
