### PR TITLE
[24] add title field for get filtered posted job API @GET

### DIFF
--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -63,6 +63,7 @@ export class JobService {
           },
         },
 
+        title: undefined,
         minAge: {
           lte: Number(searchJobDto.age) || defaultminAgeLte,
         },
@@ -136,7 +137,13 @@ export class JobService {
         },
       }
     }
-
+    //handle title substring query
+    if (searchJobDto.title) {
+      params.where.title = {
+        contains: searchJobDto.title,
+        mode: 'insensitive',
+      }
+    }
     return params
   }
   async findAll(searchJobDto: SearchJobDto, user: JwtDto) {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -37,6 +37,11 @@ export class SearchJobDto {
   page: number
 
   @IsOptional()
+  @IsString()
+  @ApiPropertyOptional()
+  title?: string
+
+  @IsOptional()
   @Type(() => Date)
   @IsDate()
   @ApiPropertyOptional()


### PR DESCRIPTION
## What did you do
- add query field ```title``` for ```GET /job```
- it's sub-string search and case-insensitive

## Demo
- https://api-dev.modela.miello.dev/swagger
- login at ```POST /auth/login``` with email ```ayame@hololive.com``` , password ```ayame123```
- get ```GET /job``` add sub-string of any title in the title field for example Designer, developer
- try swapping MALE and FEMALE in gender for more filter