### PR TITLE
[33] Implement edit job API @PUT

### DIFF
--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -55,12 +55,17 @@ export class JobController {
   @Put(':id')
   @ApiOperation({ summary: 'update job by id' })
   @ApiCreatedResponse({ type: JobIdDTO })
+  @UseTypeAuthGuard(UserType.CASTING)
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiForbiddenResponse({ description: 'User is not owner' })
   @ApiBadRequestResponse({ description: 'Wrong format' })
   @ApiNotFoundResponse({ description: 'Job not found' })
-  update(@Param('id') id: string, @Body() updateJobDto: EditJobDto) {
-    return this.jobService.update(+id, updateJobDto)
+  update(
+    @Param('id') id: string,
+    @Body() updateJobDto: EditJobDto,
+    @User() user: JwtDto,
+  ) {
+    return this.jobService.update(+id, updateJobDto, user.userId)
   }
 
   @Post()

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -1,6 +1,7 @@
 import { Job, JobStatus, Prisma } from '@modela/database'
 import {
   CreateJobDto,
+  EditJobDto,
   GetJobCardDto,
   GetJobDto,
   ShootingDto,
@@ -12,7 +13,7 @@ import { PrismaService } from 'src/database/prisma.service'
 export class JobRepository {
   constructor(private prisma: PrismaService) {}
 
-  async createJob(createJobDto: CreateJobDto, userId: number) {
+  async createJob(createJobDto: EditJobDto, userId: number) {
     const { shooting, ...field } = createJobDto
     const job = await this.prisma.job.create({
       data: {

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -24,7 +24,7 @@ export class JobRepository {
         },
       },
     })
-    return job.jobId
+    return { jobId: job.jobId }
   }
 
   async updateJob(id: number, updateJobDto: CreateJobDto) {
@@ -38,7 +38,7 @@ export class JobRepository {
         },
       },
     })
-    return updatedJob.jobId
+    return { jobId: updatedJob.jobId }
   }
 
   async getJobCount(params: {

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -29,16 +29,6 @@ export class JobRepository {
 
   async updateJob(id: number, updateJobDto: CreateJobDto, userId: number) {
     const { shooting, ...field } = updateJobDto
-    const job = await this.prisma.job.findUnique({
-      where: {
-        jobId: id,
-      },
-    })
-    if (job.castingId !== userId) {
-      throw new ForbiddenException(
-        "You don't have permission to update this job",
-      )
-    }
     const updatedJob = await this.prisma.job.update({
       where: { jobId: id },
       data: {

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -12,7 +12,7 @@ import { PrismaService } from 'src/database/prisma.service'
 export class JobRepository {
   constructor(private prisma: PrismaService) {}
 
-  async createJob(createJobDto: EditJobDto, userId: number) {
+  async createJob(createJobDto: CreateJobDto, userId: number) {
     const { shooting, ...field } = createJobDto
     const job = await this.prisma.job.create({
       data: {
@@ -27,7 +27,7 @@ export class JobRepository {
     return { jobId: job.jobId }
   }
 
-  async updateJob(id: number, updateJobDto: CreateJobDto) {
+  async updateJob(id: number, updateJobDto: EditJobDto) {
     const { shooting, ...field } = updateJobDto
     const updatedJob = await this.prisma.job.update({
       where: { jobId: id },

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -5,8 +5,7 @@ import {
   GetJobDto,
   ShootingDto,
 } from '@modela/dtos'
-import { Injectable } from '@nestjs/common'
-import { OmitType } from '@nestjs/swagger'
+import { ForbiddenException, Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
 @Injectable()
@@ -26,6 +25,30 @@ export class JobRepository {
       },
     })
     return job.jobId
+  }
+
+  async updateJob(id: number, updateJobDto: CreateJobDto, userId: number) {
+    const { shooting, ...field } = updateJobDto
+    const job = await this.prisma.job.findUnique({
+      where: {
+        jobId: id,
+      },
+    })
+    if (job.castingId !== userId) {
+      throw new ForbiddenException(
+        "You don't have permission to update this job",
+      )
+    }
+    const updatedJob = await this.prisma.job.update({
+      where: { jobId: id },
+      data: {
+        ...field,
+        Shooting: {
+          create: shooting,
+        },
+      },
+    })
+    return updatedJob.jobId
   }
 
   async getJobCount(params: {

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -1,12 +1,11 @@
-import { Job, JobStatus, Prisma } from '@modela/database'
+import { JobStatus, Prisma } from '@modela/database'
 import {
   CreateJobDto,
   EditJobDto,
   GetJobCardDto,
   GetJobDto,
-  ShootingDto,
 } from '@modela/dtos'
-import { ForbiddenException, Injectable } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
 @Injectable()
@@ -28,7 +27,7 @@ export class JobRepository {
     return job.jobId
   }
 
-  async updateJob(id: number, updateJobDto: CreateJobDto, userId: number) {
+  async updateJob(id: number, updateJobDto: CreateJobDto) {
     const { shooting, ...field } = updateJobDto
     const updatedJob = await this.prisma.job.update({
       where: { jobId: id },

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -16,8 +16,6 @@ import { JobRepository } from './job.repository'
 import { JobService } from './job.service'
 
 function createValidJob() {
-  const now = new Date()
-
   const MOCK_START_DATE = new Date()
   MOCK_START_DATE.setFullYear(MOCK_START_DATE.getFullYear() + 2)
   const MOCK_END_DATE = new Date()
@@ -409,7 +407,7 @@ describe('JobService', () => {
           .spyOn(repository, 'createJob')
           .mockResolvedValue({ jobId: result.jobId })
 
-        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+        await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
 
         expect(repository.createJob).toBeCalledWith(MOCK_JOB, MOCK_CASTING_ID)
       })

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -453,11 +453,7 @@ describe('JobService', () => {
         MOCK_JOB.title = MOCK_UPDATED_TITLE
         await service.update(newId, MOCK_JOB, MOCK_CASTING_ID)
 
-        expect(repository.updateJob).toBeCalledWith(
-          newId,
-          MOCK_JOB,
-          MOCK_CASTING_ID,
-        )
+        expect(repository.updateJob).toBeCalledWith(newId, MOCK_JOB)
       })
 
       it('should be bad request due to user not being the job owner', async () => {

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -408,7 +408,6 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get(1)[0]
-        console.log(result)
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
 
@@ -421,7 +420,6 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get(1)[0]
-        console.log(result)
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
 
@@ -444,7 +442,6 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get(1)[0]
-        console.log(result)
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
 
@@ -469,7 +466,6 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get(1)[0]
-        console.log(result)
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -1,4 +1,4 @@
-import { mock, UserType } from '@modela/database'
+import { JobStatus, mock, UserType } from '@modela/database'
 import {
   GetJobCardDto,
   GetJobCardWithMaxPageDto,
@@ -58,6 +58,7 @@ function createValidJobWithID(userId: number, jobId: number) {
     jobId: jobId,
     companyName: 'test',
     jobCastingImageUrl: 'test',
+    status: JobStatus.OPEN,
   }
   return MOCK_JOB
 }

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -16,6 +16,45 @@ import { PrismaService } from 'src/database/prisma.service'
 import { JobRepository } from './job.repository'
 import { JobService } from './job.service'
 
+function createValidJob(MOCK_CASTING_ID: number) {
+  const now = new Date()
+
+  const MOCK_JOB = {
+    ...mock('job')
+      .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
+      .get(),
+    castingId: MOCK_CASTING_ID,
+    shooting: mock('shooting').get(3),
+  }
+  MOCK_JOB.applicationDeadline = new Date()
+  MOCK_JOB.applicationDeadline.setFullYear(
+    MOCK_JOB.applicationDeadline.getFullYear() + 1,
+  )
+  // for each shooting set start date to be 2 years from now, set start time to be the same
+  MOCK_JOB.shooting.forEach((shooting) => {
+    shooting.startDate = new Date()
+    shooting.startDate.setFullYear(shooting.startDate.getFullYear() + 2)
+    shooting.startTime = now
+  })
+  // for each shooting set end date to be 3 years from now, set end time to be the same
+  MOCK_JOB.shooting.forEach((shooting) => {
+    shooting.endDate = new Date()
+    shooting.endDate.setFullYear(shooting.endDate.getFullYear() + 3)
+    shooting.endTime = now
+  })
+  // set actorCount, minAge and wage to be 1 if they are less than 1
+  if (MOCK_JOB.actorCount < 1) {
+    MOCK_JOB.actorCount = 1
+  }
+  if (MOCK_JOB.minAge < 1) {
+    MOCK_JOB.minAge = 1
+  }
+  if (MOCK_JOB.wage < 1) {
+    MOCK_JOB.wage = 1
+  }
+  return MOCK_JOB
+}
+
 describe('JobService', () => {
   let service: JobService
   let repository: JobRepository
@@ -355,90 +394,7 @@ describe('JobService', () => {
 
     describe('normal behavior', () => {
       it('should create the job successfully', async () => {
-        const now = new Date()
-
-        const MOCK_JOB = {
-          ...mock('job')
-            .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
-            .get(),
-          castingId: MOCK_CASTING_ID,
-          shooting: mock('shooting').get(3),
-        }
-        MOCK_JOB.applicationDeadline = new Date()
-        MOCK_JOB.applicationDeadline.setFullYear(
-          MOCK_JOB.applicationDeadline.getFullYear() + 1,
-        )
-        // for each shooting set start date to be 2 years from now, set start time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.startDate = new Date()
-          shooting.startDate.setFullYear(shooting.startDate.getFullYear() + 2)
-          shooting.startTime = now
-        })
-        // for each shooting set end date to be 3 years from now, set end time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.endDate = new Date()
-          shooting.endDate.setFullYear(shooting.endDate.getFullYear() + 3)
-          shooting.endTime = now
-        })
-        // set actorCount, minAge and wage to be 1 if they are less than 1
-        if (MOCK_JOB.actorCount < 1) {
-          MOCK_JOB.actorCount = 1
-        }
-        if (MOCK_JOB.minAge < 1) {
-          MOCK_JOB.minAge = 1
-        }
-        if (MOCK_JOB.wage < 1) {
-          MOCK_JOB.wage = 1
-        }
-
-        const result = mock('job').get(1)[0]
-        console.log(result)
-
-        jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
-
-        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
-
-        expect(repository.createJob).toBeCalledWith(MOCK_JOB, MOCK_CASTING_ID)
-      })
-    })
-
-    describe('normal behavior', () => {
-      it('should create the job successfully', async () => {
-        const now = new Date()
-
-        const MOCK_JOB = {
-          ...mock('job')
-            .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
-            .get(),
-          castingId: MOCK_CASTING_ID,
-          shooting: mock('shooting').get(3),
-        }
-        MOCK_JOB.applicationDeadline = new Date()
-        MOCK_JOB.applicationDeadline.setFullYear(
-          MOCK_JOB.applicationDeadline.getFullYear() + 1,
-        )
-        // for each shooting set start date to be 2 years from now, set start time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.startDate = new Date()
-          shooting.startDate.setFullYear(shooting.startDate.getFullYear() + 2)
-          shooting.startTime = now
-        })
-        // for each shooting set end date to be 3 years from now, set end time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.endDate = new Date()
-          shooting.endDate.setFullYear(shooting.endDate.getFullYear() + 3)
-          shooting.endTime = now
-        })
-        // set actorCount, minAge and wage to be 1 if they are less than 1
-        if (MOCK_JOB.actorCount < 1) {
-          MOCK_JOB.actorCount = 1
-        }
-        if (MOCK_JOB.minAge < 1) {
-          MOCK_JOB.minAge = 1
-        }
-        if (MOCK_JOB.wage < 1) {
-          MOCK_JOB.wage = 1
-        }
+        const MOCK_JOB = createValidJob(MOCK_CASTING_ID)
 
         const result = mock('job').get(1)[0]
         console.log(result)
@@ -451,41 +407,7 @@ describe('JobService', () => {
       })
 
       it('should be bad request due to date conflict', async () => {
-        const now = new Date()
-
-        const MOCK_JOB = {
-          ...mock('job')
-            .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
-            .get(),
-          castingId: MOCK_CASTING_ID,
-          shooting: mock('shooting').get(3),
-        }
-        MOCK_JOB.applicationDeadline = new Date()
-        MOCK_JOB.applicationDeadline.setFullYear(
-          MOCK_JOB.applicationDeadline.getFullYear() + 1,
-        )
-        // for each shooting set start date to be 2 years from now, set start time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.startDate = new Date()
-          shooting.startDate.setFullYear(shooting.startDate.getFullYear() + 2)
-          shooting.startTime = now
-        })
-        // for each shooting set end date to be 3 years from now, set end time to be the same
-        MOCK_JOB.shooting.forEach((shooting) => {
-          shooting.endDate = new Date()
-          shooting.endDate.setFullYear(shooting.endDate.getFullYear() + 1)
-          shooting.endTime = now
-        })
-        // set actorCount, minAge and wage to be 1 if they are less than 1
-        if (MOCK_JOB.actorCount < 1) {
-          MOCK_JOB.actorCount = 1
-        }
-        if (MOCK_JOB.minAge < 1) {
-          MOCK_JOB.minAge = 1
-        }
-        if (MOCK_JOB.wage < 1) {
-          MOCK_JOB.wage = 1
-        }
+        const MOCK_JOB = createValidJob(MOCK_CASTING_ID)
 
         const result = mock('job').get(1)[0]
         console.log(result)

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -23,7 +23,7 @@ function createValidJob(MOCK_CASTING_ID: number) {
     ...mock('job')
       .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
       .get(),
-    castingId: MOCK_CASTING_ID,
+    //castingId: MOCK_CASTING_ID,
     shooting: mock('shooting').get(3),
   }
   MOCK_JOB.applicationDeadline = new Date()
@@ -420,6 +420,58 @@ describe('JobService', () => {
 
         // expect repository.createJob to not be called
         expect(repository.createJob).not.toBeCalled()
+      })
+    })
+  })
+
+  describe('updateJob', () => {
+    const MOCK_CASTING_ID = 1
+
+    describe('normal behavior', () => {
+      it('should update the job successfully', async () => {
+        const MOCK_UPDATED_TITLE = 'updated title'
+        const MOCK_JOB = createValidJob(MOCK_CASTING_ID)
+
+        const result = mock('job').get(1)[0]
+        console.log(result)
+
+        jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
+        jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
+
+        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+        const newerId = await service.update(newId, MOCK_JOB, MOCK_CASTING_ID)
+
+        expect(repository.updateJob).toBeCalledWith(
+          newId,
+          MOCK_JOB,
+          MOCK_CASTING_ID,
+        )
+      })
+
+      it('should be bad request due to user not being the job owner', async () => {
+        const MOCK_UPDATED_TITLE = 'updated title'
+        const MOCK_INVALID_USER_ID = 2394082
+        const MOCK_JOB = createValidJob(MOCK_CASTING_ID)
+
+        const result = mock('job').get(1)[0]
+        console.log(result)
+
+        jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
+        jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
+
+        await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+
+        expect(repository.createJob).toBeCalledWith(MOCK_JOB, MOCK_CASTING_ID)
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_INVALID_USER_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        // expect repository.updateJob to not be called
+        expect(repository.updateJob).not.toBeCalled()
       })
     })
   })

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -417,6 +417,10 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get()
+        MOCK_JOB.applicationDeadline = new Date()
+        MOCK_JOB.applicationDeadline.setDate(
+          MOCK_JOB.applicationDeadline.getDate() - 1,
+        )
 
         jest
           .spyOn(repository, 'createJob')

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -711,6 +711,56 @@ describe('JobService', () => {
 
         expect(repository.updateJob).not.toBeCalled()
       })
+
+      it('should be not found due to giving an ID which should not exist', async () => {
+        const MOCK_JOB = createValidJob()
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = 98094832
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(null)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(NotFoundException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to endDate being earlier than startDate on the same day', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.shooting[0].endDate = new Date(MOCK_JOB.shooting[0].startDate)
+        MOCK_JOB.shooting[0].endDate.setMinutes(
+          MOCK_JOB.shooting[0].endDate.getMinutes() - 1,
+        )
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
     })
   })
 })

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -442,10 +442,9 @@ describe('JobService', () => {
         const MOCK_JOB = createValidJob()
 
         const result = mock('job').get()
-        jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
 
-        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+        const newId = result.jobId
 
         const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
         jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
@@ -467,10 +466,9 @@ describe('JobService', () => {
 
         const result = mock('job').get()
 
-        jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
 
-        const newId = await service.createJob(MOCK_JOB, MOCK_CASTING_ID)
+        const newId = result.jobId
 
         const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
         jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -19,28 +19,25 @@ import { JobService } from './job.service'
 function createValidJob() {
   const now = new Date()
 
+  const MOCK_START_DATE = new Date()
+  MOCK_START_DATE.setFullYear(MOCK_START_DATE.getFullYear() + 1)
+  const MOCK_END_DATE = new Date()
+  MOCK_END_DATE.setFullYear(MOCK_END_DATE.getFullYear() + 2)
+  const MOCK_APPLICATION_DEADLINE = new Date()
+  MOCK_APPLICATION_DEADLINE.setFullYear(
+    MOCK_APPLICATION_DEADLINE.getFullYear() + 1,
+  )
+
   const MOCK_JOB = {
     ...mock('job')
       .omit(['castingId', 'createdAt', 'updatedAt', 'jobId', 'status'])
+      .override({ applicationDeadline: MOCK_APPLICATION_DEADLINE })
       .get(),
-    shooting: mock('shooting').get(3),
+    shooting: mock('shooting')
+      .override({ startDate: MOCK_START_DATE, endDate: MOCK_END_DATE })
+      .get(3),
   }
-  MOCK_JOB.applicationDeadline = new Date()
-  MOCK_JOB.applicationDeadline.setFullYear(
-    MOCK_JOB.applicationDeadline.getFullYear() + 1,
-  )
-  // for each shooting set start date to be 2 years from now, set start time to be the same
-  MOCK_JOB.shooting.forEach((shooting) => {
-    shooting.startDate = new Date()
-    shooting.startDate.setFullYear(shooting.startDate.getFullYear() + 2)
-    shooting.startTime = now
-  })
-  // for each shooting set end date to be 3 years from now, set end time to be the same
-  MOCK_JOB.shooting.forEach((shooting) => {
-    shooting.endDate = new Date()
-    shooting.endDate.setFullYear(shooting.endDate.getFullYear() + 3)
-    shooting.endTime = now
-  })
+
   // set actorCount, minAge and wage to be 1 if they are less than 1
   if (MOCK_JOB.actorCount < 1) {
     MOCK_JOB.actorCount = 1

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -506,6 +506,208 @@ describe('JobService', () => {
 
         expect(repository.updateJob).not.toBeCalled()
       })
+
+      it('should be bad request due to endDate being earlier than startDate', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.shooting[0].endDate = new Date(MOCK_JOB.shooting[0].startDate)
+        MOCK_JOB.shooting[0].endDate.setDate(
+          MOCK_JOB.shooting[0].endDate.getDate() - 1,
+        )
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to minAge being higher than maxAge', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.minAge = 100
+        MOCK_JOB.maxAge = 10
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to startDate being before applicationDeadline', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.shooting[0].startDate = new Date(MOCK_JOB.applicationDeadline)
+        MOCK_JOB.shooting[0].startDate.setDate(
+          MOCK_JOB.shooting[0].startDate.getDate() - 1,
+        )
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to minAge being higher than maxAge', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.minAge = 100
+        MOCK_JOB.maxAge = 10
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to minAge being less than 1', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.minAge = 0
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to actorCount being less than 1', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.actorCount = 0
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+
+      it('should be bad request due to wage being less than 0', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.wage = -1
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
+      it('should be bad request due to applicationDeadline being before current time', async () => {
+        const MOCK_JOB = createValidJob()
+        MOCK_JOB.applicationDeadline = new Date()
+        MOCK_JOB.applicationDeadline.setDate(
+          MOCK_JOB.applicationDeadline.getDate() - 1,
+        )
+
+        const result = mock('job').get()
+
+        jest
+          .spyOn(repository, 'updateJob')
+          .mockResolvedValue({ jobId: result.jobId })
+
+        const newId = result.jobId
+
+        const MOCK_GET_JOB = createValidJobWithID(MOCK_CASTING_ID, newId)
+        jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
+
+        MOCK_JOB.title = MOCK_UPDATED_TITLE
+
+        await expect(
+          service.update(newId, MOCK_JOB, MOCK_CASTING_ID),
+        ).rejects.toThrow(BadRequestException)
+
+        expect(repository.updateJob).not.toBeCalled()
+      })
     })
   })
 })

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -445,7 +445,7 @@ describe('JobService', () => {
         jest.spyOn(repository, 'getJobById').mockResolvedValue(MOCK_GET_JOB)
 
         MOCK_JOB.title = MOCK_UPDATED_TITLE
-        const newerId = await service.update(newId, MOCK_JOB, MOCK_CASTING_ID)
+        await service.update(newId, MOCK_JOB, MOCK_CASTING_ID)
 
         expect(repository.updateJob).toBeCalledWith(
           newId,

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -10,7 +10,6 @@ import {
   NotFoundException,
 } from '@nestjs/common'
 import { Test, TestingModule } from '@nestjs/testing'
-import exp from 'constants'
 import { PrismaService } from 'src/database/prisma.service'
 
 import { JobRepository } from './job.repository'
@@ -304,7 +303,6 @@ describe('JobService', () => {
           limit: limitQuery,
           page: pageQuery,
         }
-        const thisReqParams = reqParams
         const result = new GetJobCardWithMaxPageDto()
         result.jobs = itMockedJobData.slice(
           limitQuery * (pageQuery - 1),

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -407,7 +407,7 @@ describe('JobService', () => {
       it('should create the job successfully', async () => {
         const MOCK_JOB = createValidJob()
 
-        const result = mock('job').get(1)[0]
+        const result = mock('job').get()
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
 
@@ -419,7 +419,7 @@ describe('JobService', () => {
       it('should be bad request due to date conflict', async () => {
         const MOCK_JOB = createValidJob()
 
-        const result = mock('job').get(1)[0]
+        const result = mock('job').get()
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
 
@@ -441,7 +441,7 @@ describe('JobService', () => {
         const MOCK_UPDATED_TITLE = 'updated title'
         const MOCK_JOB = createValidJob()
 
-        const result = mock('job').get(1)[0]
+        const result = mock('job').get()
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
 
@@ -465,7 +465,7 @@ describe('JobService', () => {
         const MOCK_INVALID_USER_ID = 2394082
         const MOCK_JOB = createValidJob()
 
-        const result = mock('job').get(1)[0]
+        const result = mock('job').get()
 
         jest.spyOn(repository, 'createJob').mockResolvedValue(result.jobId)
         jest.spyOn(repository, 'updateJob').mockResolvedValue(result.jobId)
@@ -484,7 +484,6 @@ describe('JobService', () => {
           service.update(newId, MOCK_JOB, MOCK_INVALID_USER_ID),
         ).rejects.toThrow(ForbiddenException)
 
-        // expect repository.updateJob to not be called
         expect(repository.updateJob).not.toBeCalled()
       })
     })

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -256,7 +256,7 @@ export class JobService {
     }
 
     this.validateJobDto(updateJobDto)
-    return this.repository.updateJob(id, updateJobDto, userId)
+    return this.repository.updateJob(id, updateJobDto)
   }
 
   remove(id: number) {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -248,7 +248,6 @@ export class JobService {
 
   async update(id: number, updateJobDto: EditJobDto, userId: number) {
     const job = await this.repository.getJobById(id)
-    console.log(job.castingId, userId)
     if (job.castingId !== userId) {
       throw new ForbiddenException(
         "You don't have permission to update this job",

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -31,7 +31,7 @@ export class JobService {
     for (let i = 0; i < createJobDto.shooting.length; i++) {
       if (
         createJobDto.shooting[i].startTime > createJobDto.shooting[i].endTime &&
-        createJobDto.shooting[i].startDate == createJobDto.shooting[i].endDate
+        createJobDto.shooting[i].startDate === createJobDto.shooting[i].endDate
       ) {
         throw new BadRequestException(
           'startTime is greater than endTime in the same day',
@@ -248,6 +248,7 @@ export class JobService {
 
   async update(id: number, updateJobDto: EditJobDto, userId: number) {
     const job = await this.repository.getJobById(id)
+    console.log(job.castingId, userId)
     if (job.castingId !== userId) {
       throw new ForbiddenException(
         "You don't have permission to update this job",

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -22,7 +22,7 @@ import { JobRepository } from './job.repository'
 export class JobService {
   constructor(private repository: JobRepository) {}
 
-  async createJob(createJobDto: CreateJobDto, userId: number) {
+  private validateJobDto(createJobDto: CreateJobDto) {
     // if minAge is greater than maxAge, throw error
     if (createJobDto.minAge > createJobDto.maxAge) {
       throw new BadRequestException('minAge is greater than maxAge')
@@ -67,6 +67,10 @@ export class JobService {
     if (applicationDeadline < now) {
       throw new BadRequestException('applicationDeadline is less than now')
     }
+  }
+
+  async createJob(createJobDto: CreateJobDto, userId: number) {
+    this.validateJobDto(createJobDto)
     try {
       return await this.repository.createJob(createJobDto, userId)
     } catch (e) {
@@ -243,7 +247,7 @@ export class JobService {
   }
 
   update(id: number, updateJobDto: EditJobDto) {
-    return `This action updates a #${id} job`
+    return null
   }
 
   remove(id: number) {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -246,8 +246,9 @@ export class JobService {
     return jobDetail
   }
 
-  update(id: number, updateJobDto: EditJobDto) {
-    return null
+  update(id: number, updateJobDto: EditJobDto, userId: number) {
+    this.validateJobDto(updateJobDto)
+    return this.repository.updateJob(id, updateJobDto, userId)
   }
 
   remove(id: number) {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -248,6 +248,7 @@ export class JobService {
 
   async update(id: number, updateJobDto: EditJobDto, userId: number) {
     const job = await this.repository.getJobById(id)
+    if (!job) throw new NotFoundException('Job not found')
     if (job.castingId !== userId) {
       throw new ForbiddenException(
         "You don't have permission to update this job",

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -246,7 +246,14 @@ export class JobService {
     return jobDetail
   }
 
-  update(id: number, updateJobDto: EditJobDto, userId: number) {
+  async update(id: number, updateJobDto: EditJobDto, userId: number) {
+    const job = await this.repository.getJobById(id)
+    if (job.castingId !== userId) {
+      throw new ForbiddenException(
+        "You don't have permission to update this job",
+      )
+    }
+
     this.validateJobDto(updateJobDto)
     return this.repository.updateJob(id, updateJobDto, userId)
   }

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -209,6 +209,9 @@ export class GetJobCardWithMaxPageDto {
 
   @ApiProperty()
   maxPage: number
+
+  @ApiProperty()
+  status: JobStatus
 }
 
 export class GetJobDto extends EditJobDto {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -209,9 +209,6 @@ export class GetJobCardWithMaxPageDto {
 
   @ApiProperty()
   maxPage: number
-
-  @ApiProperty()
-  status: JobStatus
 }
 
 export class GetJobDto extends EditJobDto {
@@ -223,6 +220,9 @@ export class GetJobDto extends EditJobDto {
 
   @ApiProperty()
   jobCastingImageUrl: string
+
+  @ApiProperty()
+  status: JobStatus
 }
 
 export class JobIdDTO {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -128,62 +128,6 @@ export class ShootingDto implements Partial<Shooting> {
 
 type EditJobType = Partial<Job> & { shooting: ShootingDto[] }
 
-export class EditJobDto implements EditJobType {
-  @IsString()
-  @IsNotEmpty()
-  @ApiProperty()
-  title: string
-
-  @IsString()
-  @IsNotEmpty()
-  @ApiProperty()
-  description: string
-
-  @IsEnum(JobStatus, { each: true })
-  @IsNotEmpty()
-  @ApiProperty()
-  status: JobStatus
-
-  @IsString()
-  @IsNotEmpty()
-  @ApiProperty()
-  role: string
-
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty()
-  minAge: number
-
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty()
-  maxAge: number
-
-  @IsEnum(Gender, { each: true })
-  @IsNotEmpty()
-  @ApiProperty()
-  gender: Gender
-
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty()
-  actorCount: number
-
-  @IsNumber()
-  @IsNotEmpty()
-  @ApiProperty()
-  wage: number
-
-  @IsNotEmpty()
-  @IsDateString()
-  @ApiProperty()
-  applicationDeadline: Date
-
-  @IsNotEmpty()
-  @ApiProperty({ type: ShootingDto, isArray: true })
-  shooting: ShootingDto[]
-}
-
 export class CreateJobDto {
   @IsString()
   @IsNotEmpty()
@@ -238,6 +182,10 @@ export class CreateJobDto {
   @IsNotEmpty()
   @ApiProperty({ type: ShootingDto, isArray: true })
   shooting: ShootingDto[]
+}
+
+export class EditJobDto extends CreateJobDto implements EditJobType {
+  
 }
 
 export class GetJobCardDto extends OmitType(EditJobDto, [

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -201,6 +201,9 @@ export class GetJobCardDto extends OmitType(EditJobDto, [
 
   @ApiProperty()
   jobCastingImageUrl: string
+
+  @ApiProperty()
+  status: JobStatus
 }
 
 export class GetJobCardWithMaxPageDto {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -128,7 +128,7 @@ export class ShootingDto implements Partial<Shooting> {
 
 type EditJobType = Partial<Job> & { shooting: ShootingDto[] }
 
-export class CreateJobDto {
+export class CreateJobDto  implements EditJobType {
   @IsString()
   @IsNotEmpty()
   @ApiProperty()
@@ -184,7 +184,7 @@ export class CreateJobDto {
   shooting: ShootingDto[]
 }
 
-export class EditJobDto extends CreateJobDto implements EditJobType {
+export class EditJobDto extends CreateJobDto{
   
 }
 

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -10,7 +10,6 @@ import {
   IsOptional,
   IsString,
   Max,
-  min,
   Min,
 } from 'class-validator'
 import { Casting, Gender, Job, JobStatus, Shooting } from '@modela/database'


### PR DESCRIPTION
## What did you do

- Implemented edit job feature
- also includes both successful and forbidden test units
- fixed a few bugs/unused code from post-job as well

## Demo

- login into service as caster
```
register
{
  "email": "ayame@hololive.com",
  "password": "ayame123",
  "firstName": "Ayame",
  "lastName": "Nakiri",
  "prefix": "Mrs.",
  "nationality": "Japanese",
  "ssn": "1212312121",
  "gender": "FEMALE",
  "phoneNumber": "0123456789",
  "idCardImageUrl": "hololive.com"
}

login
{
  "email": "yagoo@hololive.com",
  "password": "yagoo123"
}
```
- post job
- put job with the following
```
sample edit
{
  "title": "NEW UPDATE",
  "description": "IT WORKS",
  "status": "OPEN",
  "role": "WORKS",
  "minAge": 1,
  "maxAge": 5,
  "gender": "ANY",
  "actorCount": 1,
  "wage": 555555,
  "applicationDeadline": "2024-02-11T17:42:50.556Z",
  "shooting": [
    {
      "shootingLocation": "string",
      "startDate": "2024-02-11T17:42:50.556Z",
      "endDate": "2024-02-11T17:42:50.556Z",
      "startTime": "2024-02-11T17:42:50.556Z",
      "endTime": "2024-02-11T17:42:50.556Z"
    }
  ]
}
```
- pnpm studio
