### PR TITLE
[19] fix job search

### DIFF
--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -81,23 +81,25 @@ describe('JobService', () => {
 
   describe('findAll', () => {
     //generate default where query
+    const minInt32 = -2147483647 //min int32
+    const maxInt32 = 2147483647 //max int32
     const defaultWhere = {
       Shooting: undefined,
       title: undefined,
       castingId: undefined,
       gender: undefined,
       maxAge: {
-        gte: Number.MIN_SAFE_INTEGER,
+        gte: minInt32,
       },
       minAge: {
-        lte: Number.MAX_SAFE_INTEGER,
+        lte: maxInt32,
       },
       status: {
         in: ['OPEN'],
       },
       wage: {
-        gte: Number.MIN_SAFE_INTEGER,
-        lte: Number.MAX_SAFE_INTEGER,
+        gte: minInt32,
+        lte: maxInt32,
       },
     }
     //const for all findAll test
@@ -310,8 +312,8 @@ describe('JobService', () => {
 
         const thisWhere = defaultWhere
         thisWhere.wage = {
-          gte: Number.MIN_SAFE_INTEGER,
-          lte: Number.MAX_SAFE_INTEGER,
+          gte: minInt32,
+          lte: maxInt32,
         }
         thisWhere.castingId = MOCK_CASTING_ID
         const prismaParams = {

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -82,39 +82,22 @@ describe('JobService', () => {
   describe('findAll', () => {
     //generate default where query
     const defaultWhere = {
-      Shooting: {
-        every: {
-          endDate: {
-            lte: new Date('9999-12-31T23:59:59.000Z'),
-          },
-          endTime: {
-            lte: new Date('1970-01-01T23:59:59.000Z'),
-          },
-          startDate: {
-            gte: new Date('0001-01-01T00:00:00.000Z'),
-          },
-          startTime: {
-            gte: new Date('1970-01-01T00:00:00.000Z'),
-          },
-        },
-        some: {
-          shootingLocation: undefined,
-        },
-      },
+      Shooting: undefined,
+      title: undefined,
       castingId: undefined,
       gender: undefined,
       maxAge: {
-        gte: 0,
+        gte: Number.MIN_SAFE_INTEGER,
       },
       minAge: {
-        lte: 999,
+        lte: Number.MAX_SAFE_INTEGER,
       },
       status: {
         in: ['OPEN'],
       },
       wage: {
-        gte: 0,
-        lte: 999999999,
+        gte: Number.MIN_SAFE_INTEGER,
+        lte: Number.MAX_SAFE_INTEGER,
       },
     }
     //const for all findAll test
@@ -327,8 +310,8 @@ describe('JobService', () => {
 
         const thisWhere = defaultWhere
         thisWhere.wage = {
-          gte: 0,
-          lte: 999999999,
+          gte: Number.MIN_SAFE_INTEGER,
+          lte: Number.MAX_SAFE_INTEGER,
         }
         thisWhere.castingId = MOCK_CASTING_ID
         const prismaParams = {

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -81,7 +81,6 @@ describe('JobService', () => {
 
   describe('findAll', () => {
     //generate default where query
-    const minInt32 = -2147483648 //min int32
     const maxInt32 = 2147483647 //max int32
     const defaultWhere = {
       Shooting: undefined,
@@ -89,7 +88,7 @@ describe('JobService', () => {
       castingId: undefined,
       gender: undefined,
       maxAge: {
-        gte: minInt32,
+        gte: 0,
       },
       minAge: {
         lte: maxInt32,
@@ -98,7 +97,7 @@ describe('JobService', () => {
         in: ['OPEN'],
       },
       wage: {
-        gte: minInt32,
+        gte: 0,
         lte: maxInt32,
       },
     }
@@ -312,7 +311,7 @@ describe('JobService', () => {
 
         const thisWhere = defaultWhere
         thisWhere.wage = {
-          gte: minInt32,
+          gte: 0,
           lte: maxInt32,
         }
         thisWhere.castingId = MOCK_CASTING_ID

--- a/apps/api/src/modules/job/job.service.spec.ts
+++ b/apps/api/src/modules/job/job.service.spec.ts
@@ -81,7 +81,7 @@ describe('JobService', () => {
 
   describe('findAll', () => {
     //generate default where query
-    const minInt32 = -2147483647 //min int32
+    const minInt32 = -2147483648 //min int32
     const maxInt32 = 2147483647 //max int32
     const defaultWhere = {
       Shooting: undefined,

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -89,7 +89,7 @@ export class JobService {
     const defaultStartTime = new Date('1970-01-01T00:00:00Z')
     const defaultEndTime = new Date('1970-01-01T23:59:59Z')
 
-    const minInt32 = -2147483647 //min int32
+    const minInt32 = -2147483648 //min int32
     const maxInt32 = 2147483647 //max int32
     const defaultminAgeLte = maxInt32
     const defaultMaxAgeGte = minInt32

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -89,10 +89,10 @@ export class JobService {
     const defaultStartTime = new Date('1970-01-01T00:00:00Z')
     const defaultEndTime = new Date('1970-01-01T23:59:59Z')
 
-    const defaultminAgeLte = 999
-    const defaultMaxAgeGte = 0
-    const defaultMinWageGte = 0
-    const defaultMaxWageLte = 999999999
+    const defaultminAgeLte = Number.MAX_SAFE_INTEGER
+    const defaultMaxAgeGte = Number.MIN_SAFE_INTEGER
+    const defaultMinWageGte = Number.MIN_SAFE_INTEGER
+    const defaultMaxWageLte = Number.MAX_SAFE_INTEGER
 
     const params = {
       //take and skip from limit and page
@@ -169,14 +169,6 @@ export class JobService {
       }
     }
     //handle shooting query
-    console.log(
-      'shooting :',
-      searchJobDto.location,
-      searchJobDto.startDate,
-      searchJobDto.endDate,
-      searchJobDto.startTime,
-      searchJobDto.endTime,
-    )
     if (
       searchJobDto.location ||
       searchJobDto.startDate ||
@@ -184,14 +176,6 @@ export class JobService {
       searchJobDto.startTime ||
       searchJobDto.endTime
     ) {
-      console.log(
-        'shooting in if :',
-        searchJobDto.location,
-        searchJobDto.startDate,
-        searchJobDto.endDate,
-        searchJobDto.startTime,
-        searchJobDto.endTime,
-      )
       params.where.Shooting = {
         every: {
           startDate: {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -89,10 +89,12 @@ export class JobService {
     const defaultStartTime = new Date('1970-01-01T00:00:00Z')
     const defaultEndTime = new Date('1970-01-01T23:59:59Z')
 
-    const defaultminAgeLte = Number.MAX_SAFE_INTEGER
-    const defaultMaxAgeGte = Number.MIN_SAFE_INTEGER
-    const defaultMinWageGte = Number.MIN_SAFE_INTEGER
-    const defaultMaxWageLte = Number.MAX_SAFE_INTEGER
+    const minInt32 = -2147483647 //min int32
+    const maxInt32 = 2147483647 //max int32
+    const defaultminAgeLte = maxInt32
+    const defaultMaxAgeGte = minInt32
+    const defaultMinWageGte = minInt32
+    const defaultMaxWageLte = maxInt32
 
     const params = {
       //take and skip from limit and page
@@ -176,6 +178,20 @@ export class JobService {
       searchJobDto.startTime ||
       searchJobDto.endTime
     ) {
+      //ignore millisecond (Timezone offset is considered as millisecond)
+      //assume that user will not search with millisecond and in database we don't have timezone
+
+      let queryStartTime = defaultStartTime
+      if (searchJobDto.startTime) {
+        queryStartTime = new Date(searchJobDto.startTime)
+        queryStartTime.setMilliseconds(0)
+      }
+      let queryEndTime = defaultEndTime
+      if (searchJobDto.endTime) {
+        queryEndTime = new Date(searchJobDto.endTime)
+        queryEndTime.setMilliseconds(0)
+      }
+
       params.where.Shooting = {
         every: {
           startDate: {
@@ -185,10 +201,10 @@ export class JobService {
             lte: searchJobDto.endDate || defaultEndDate,
           },
           startTime: {
-            gte: searchJobDto.startTime || defaultStartTime,
+            gte: queryStartTime,
           },
           endTime: {
-            lte: searchJobDto.endTime || defaultEndTime,
+            lte: queryEndTime,
           },
         },
         some: {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -89,11 +89,10 @@ export class JobService {
     const defaultStartTime = new Date('1970-01-01T00:00:00Z')
     const defaultEndTime = new Date('1970-01-01T23:59:59Z')
 
-    const minInt32 = -2147483648 //min int32
     const maxInt32 = 2147483647 //max int32
     const defaultminAgeLte = maxInt32
-    const defaultMaxAgeGte = minInt32
-    const defaultMinWageGte = minInt32
+    const defaultMaxAgeGte = 0
+    const defaultMinWageGte = 0
     const defaultMaxWageLte = maxInt32
 
     const params = {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -101,25 +101,7 @@ export class JobService {
       //filtering
       where: {
         //job always have shooting
-        Shooting: {
-          every: {
-            startDate: {
-              gte: searchJobDto.startDate || defaultStartDate,
-            },
-            endDate: {
-              lte: searchJobDto.endDate || defaultEndDate,
-            },
-            startTime: {
-              gte: searchJobDto.startTime || defaultStartTime,
-            },
-            endTime: {
-              lte: searchJobDto.endTime || defaultEndTime,
-            },
-          },
-          some: {
-            shootingLocation: undefined,
-          },
-        },
+        Shooting: undefined,
 
         title: undefined,
         minAge: {
@@ -186,12 +168,50 @@ export class JobService {
         }
       }
     }
-    //handle location substring query
-    if (searchJobDto.location) {
-      params.where.Shooting.some = {
-        shootingLocation: {
-          contains: searchJobDto.location,
-          mode: 'insensitive',
+    //handle shooting query
+    console.log(
+      'shooting :',
+      searchJobDto.location,
+      searchJobDto.startDate,
+      searchJobDto.endDate,
+      searchJobDto.startTime,
+      searchJobDto.endTime,
+    )
+    if (
+      searchJobDto.location ||
+      searchJobDto.startDate ||
+      searchJobDto.endDate ||
+      searchJobDto.startTime ||
+      searchJobDto.endTime
+    ) {
+      console.log(
+        'shooting in if :',
+        searchJobDto.location,
+        searchJobDto.startDate,
+        searchJobDto.endDate,
+        searchJobDto.startTime,
+        searchJobDto.endTime,
+      )
+      params.where.Shooting = {
+        every: {
+          startDate: {
+            gte: searchJobDto.startDate || defaultStartDate,
+          },
+          endDate: {
+            lte: searchJobDto.endDate || defaultEndDate,
+          },
+          startTime: {
+            gte: searchJobDto.startTime || defaultStartTime,
+          },
+          endTime: {
+            lte: searchJobDto.endTime || defaultEndTime,
+          },
+        },
+        some: {
+          shootingLocation: {
+            contains: searchJobDto.location,
+            mode: 'insensitive',
+          },
         },
       }
     }

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -19,15 +19,17 @@ export enum SearchJobStatus {
   'CLOSE' = 'CLOSE',
 }
 
+const minInt32 = -2147483648 //min int32
+const maxInt32 = 2147483647 //max int32
 export class SearchJobDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
   @Min(1)
   @Max(20)
-  @ApiPropertyOptional({
+  @ApiPropertyOptional({ 
     default: 20,
-  }) //Will set default again in job.service.ts
+  }) //Only for test in swagger, will set default again in job.service.ts
   limit: number
 
   @IsOptional()
@@ -36,7 +38,7 @@ export class SearchJobDto {
   @Min(1)
   @ApiPropertyOptional({
     default: 1,
-  }) //Will set default again in job.service.ts
+  }) //Only for test in swagger, Will set default again in job.service.ts
   page: number
 
   @IsOptional()
@@ -76,18 +78,24 @@ export class SearchJobDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
+  @Min(minInt32)
+  @Max(maxInt32)
   @ApiPropertyOptional()
   age?: number
 
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
+  @Min(minInt32)
+  @Max(maxInt32)
   @ApiPropertyOptional()
   minWage?: number
 
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
+  @Min(minInt32)
+  @Max(maxInt32)
   @ApiPropertyOptional()
   maxWage?: number
 

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -19,7 +19,6 @@ export enum SearchJobStatus {
   'CLOSE' = 'CLOSE',
 }
 
-const minInt32 = -2147483648 //min int32
 const maxInt32 = 2147483647 //max int32
 export class SearchJobDto {
   @IsOptional()
@@ -78,7 +77,7 @@ export class SearchJobDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
-  @Min(minInt32)
+  @Min(0)
   @Max(maxInt32)
   @ApiPropertyOptional()
   age?: number
@@ -86,7 +85,7 @@ export class SearchJobDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
-  @Min(minInt32)
+  @Min(0)
   @Max(maxInt32)
   @ApiPropertyOptional()
   minWage?: number
@@ -94,7 +93,7 @@ export class SearchJobDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
-  @Min(minInt32)
+  @Min(0)
   @Max(maxInt32)
   @ApiPropertyOptional()
   maxWage?: number


### PR DESCRIPTION
## What did you do
- make jobs that do not have shooting visible when not filtered
- set new bound for max and min integer for wage and age from 0 to 2147483647
- ignore the timezone of ISO format startTime and endTime when querying

## Limitation or concern
- age and wage or any number (maybe?) that are "Int" in the database schema can only handle Int32 (+-2147483647)
- ignore the timezone corresponding to database

## Demo
- https://dev.modela.miello.dev/ (login first)
- search job using startTime from 13:00 to 16:00  should see the "test 13:00 to 16:00" job 
- should see "not have shooting" job's title
