### PR TITLE
[33] Implement edit job API @PUT

### DIFF
--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -257,7 +257,8 @@ export class JobService {
         "You don't have permission to update this job",
       )
     }
-
+    if (job.status !== JobStatus.OPEN)
+      throw new BadRequestException("You can't update job that is not open.")
     this.validateJobDto(updateJobDto)
     return this.repository.updateJob(id, updateJobDto)
   }

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -258,7 +258,7 @@ export class JobService {
       )
     }
     if (job.status !== JobStatus.OPEN)
-      throw new BadRequestException("You can't update job that is not open.")
+      throw new ForbiddenException("You can't update job that is not open.")
     this.validateJobDto(updateJobDto)
     return this.repository.updateJob(id, updateJobDto)
   }


### PR DESCRIPTION
## What did you do

- Prevented editing non-open job

## Demo

- sign up and create a job
```
SIGN UP
{
  "email": "casting@gmail.com",
  "password": "password",
  "firstName": "name",
  "lastName": "surname",
  "companyId": "0123456789012",
  "companyName": "google",
  "employmentCertUrl": "google.com"
}
JOB 
{
  "title": "TEST JOB",
  "description": "EDIT ME",
  "status": "OPEN",
  "role": "WORKS",
  "minAge": 1,
  "maxAge": 5,
  "gender": "ANY",
  "actorCount": 1,
  "wage": 555555,
  "applicationDeadline": "2024-02-11T17:42:50.556Z",
  "shooting": [
    {
      "shootingLocation": "string",
      "startDate": "2024-02-11T17:42:50.556Z",
      "endDate": "2024-02-11T17:42:50.556Z",
      "startTime": "2024-02-11T17:42:50.556Z",
      "endTime": "2024-02-11T17:42:50.556Z"
    }
  ]
}
```
- pnpm studio then edit the job status to anything else
- put job with the same json above
- it should raise a `Bad Request` error saying that the job cannot be edited