### PR TITLE
[93][96][99][105][108] Implement get pending registration and accept and reject actor's registration API

### DIFF
--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -14,8 +14,8 @@ import { UseTypeAuthGuard } from '../auth/misc/jwt.decorator'
 import { User } from '../auth/misc/user.decorator'
 import { UserService } from './user.service'
 
-@ApiTags('user')
-@Controller('user')
+@ApiTags('users')
+@Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -42,7 +42,7 @@ export class UserController {
   @ApiOperation({ summary: 'accept or reject user with id' })
   @ApiOkResponse({ type: GetUserDto })
   @ApiNotFoundResponse({ description: 'user not found' })
-  updateExample(
+  updateUserStatus(
     @Param('id') id: number,
     @Query() updateUserStatusDto: UpdateUserStatusDto,
   ) {

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -34,6 +34,14 @@ export class UserController {
     return this.userService.getUserData(user.userId)
   }
 
+  @Get('pending')
+  @UseTypeAuthGuard(UserType.ADMIN)
+  @ApiOperation({ summary: 'get all user pending for admin' })
+  @ApiOkResponse({ type: GetUserDto, isArray: true })
+  getPendingUser() {
+    return this.userService.getPendingUsers()
+  }
+
   @Put(':id/verification')
   @UseTypeAuthGuard(UserType.ADMIN)
   @ApiOperation({ summary: 'accept or reject user with id' })

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,14 +1,21 @@
-import { GetUserDto, JwtDto } from '@modela/dtos'
-import { Controller, Get, UseGuards } from '@nestjs/common'
+import {
+  GetUserDto,
+  JwtDto,
+  UpdateUserVerificationDto,
+  UserType,
+} from '@modela/dtos'
+import { Controller, Get, Param, Put, Query, UseGuards } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import {
   ApiBadRequestResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 
+import { UseTypeAuthGuard } from '../auth/misc/jwt.decorator'
 import { User } from '../auth/misc/user.decorator'
 import { UserService } from './user.service'
 
@@ -25,5 +32,20 @@ export class UserController {
   @ApiBadRequestResponse({ description: 'Wrong format' })
   getUserData(@User() user: JwtDto) {
     return this.userService.getUserData(user.userId)
+  }
+
+  @Put(':id/verification')
+  @UseTypeAuthGuard(UserType.ADMIN)
+  @ApiOperation({ summary: 'accept or reject user with id' })
+  @ApiOkResponse({ type: GetUserDto })
+  @ApiNotFoundResponse({ description: 'user not found' })
+  updateExample(
+    @Param('id') id: number,
+    @Query() updateUserVerificationDto: UpdateUserVerificationDto,
+  ) {
+    return this.userService.updateUserVerification(
+      +id,
+      updateUserVerificationDto,
+    )
   }
 }

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,5 +1,5 @@
 import { GetUserDto, JwtDto, UpdateUserStatusDto, UserType } from '@modela/dtos'
-import { Controller, Get, Param, Put, Query, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Param, Put, UseGuards } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import {
   ApiBadRequestResponse,
@@ -43,8 +43,8 @@ export class UserController {
   @ApiOkResponse({ type: GetUserDto })
   @ApiNotFoundResponse({ description: 'user not found' })
   updateUserStatus(
-    @Param('id') id: number,
-    @Query() updateUserStatusDto: UpdateUserStatusDto,
+    @Param('id') id: string,
+    @Body() updateUserStatusDto: UpdateUserStatusDto,
   ) {
     return this.userService.updateUserStatus(+id, updateUserStatusDto)
   }

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,9 +1,4 @@
-import {
-  GetUserDto,
-  JwtDto,
-  UpdateUserVerificationDto,
-  UserType,
-} from '@modela/dtos'
+import { GetUserDto, JwtDto, UpdateUserStatusDto, UserType } from '@modela/dtos'
 import { Controller, Get, Param, Put, Query, UseGuards } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import {
@@ -49,11 +44,8 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'user not found' })
   updateExample(
     @Param('id') id: number,
-    @Query() updateUserVerificationDto: UpdateUserVerificationDto,
+    @Query() updateUserStatusDto: UpdateUserStatusDto,
   ) {
-    return this.userService.updateUserVerification(
-      +id,
-      updateUserVerificationDto,
-    )
+    return this.userService.updateUserStatus(+id, updateUserStatusDto)
   }
 }

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -41,7 +41,7 @@ export class UserRepository {
     const users = await this.prisma.user.findMany({
       ...params,
       orderBy: {
-        updatedAt: Prisma.SortOrder.desc,
+        updatedAt: Prisma.SortOrder.asc,
       },
       include: {
         Casting: true,

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -47,26 +47,27 @@ export class UserRepository {
         Casting: true,
         Actor: true,
       },
-      //TODO: filter ??????????????????
     })
     const pendingUsers: PendingUserDto[] = []
     for (let i = 0; i < users.length; i++) {
       const user = users[i]
       const aPendingUser = {
-        userId: user.userId,
-        firstName: user.firstName,
-        middleName: user.middleName,
-        lastName: user.lastName,
-        type: user.Casting ? UserType.CASTING : UserType.ACTOR, //TODO: does we need to verify admin?
-        ...(user.Casting && {
-          companyName: user.Casting.companyName,
-          companyId: user.Casting.companyId,
-          employmentCertUrl: user.Casting.employmentCertUrl,
-        }),
-        ...(user.Actor && {
-          idCardImageUrl: user.Actor.idCardImageUrl,
-          ssn: user.Actor.ssn,
-        }),
+        type: user.Casting ? UserType.CASTING : UserType.ACTOR,
+        data: {
+          userId: user.userId,
+          firstName: user.firstName,
+          middleName: user.middleName,
+          lastName: user.lastName,
+          ...(user.Casting && {
+            companyName: user.Casting.companyName,
+            companyId: user.Casting.companyId,
+            employmentCertUrl: user.Casting.employmentCertUrl,
+          }),
+          ...(user.Actor && {
+            idCardImageUrl: user.Actor.idCardImageUrl,
+            ssn: user.Actor.ssn,
+          }),
+        },
       }
       pendingUsers.push(aPendingUser)
     }

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { Casting, User } from '@modela/database'
+import { Casting, Prisma, User } from '@modela/database'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -15,6 +15,18 @@ export class UserRepository {
   async getCastingById(castingId: number): Promise<Casting> {
     return await this.prisma.casting.findUnique({
       where: { castingId },
+    })
+  }
+
+  async getUsers(params: {
+    skip?: number
+    take?: number
+    cursor?: Prisma.UserWhereUniqueInput
+    where?: Prisma.UserWhereInput
+    orderBy?: Prisma.UserOrderByWithRelationInput
+  }): Promise<User[]> {
+    return await this.prisma.user.findMany({
+      ...params,
     })
   }
 

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -17,4 +17,14 @@ export class UserRepository {
       where: { castingId },
     })
   }
+
+  async updateUserVerification(userId: number): Promise<User> {
+    //accept user
+    return await this.prisma.user.update({
+      where: { userId },
+      data: {
+        isVerified: true,
+      },
+    })
+  }
 }

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -62,6 +62,7 @@ export class UserRepository {
       where: { userId },
       data: {
         status: updateUserStatusDto.status,
+        rejectedReason: updateUserStatusDto.rejectedReason,
       },
     })
   }

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -52,31 +52,22 @@ export class UserRepository {
     const pendingUsers: PendingUserDto[] = []
     for (let i = 0; i < users.length; i++) {
       const user = users[i]
-      console.log(user)
       const aPendingUser = {
         userId: user.userId,
         firstName: user.firstName,
         middleName: user.middleName,
         lastName: user.lastName,
         type: user.Casting ? UserType.CASTING : UserType.ACTOR, //TODO: does we need to verify admin?
-      }
-      /*
-      if(user.Casting) {
-        aPendingUser = {
-          ...aPendingUser,
+        ...(user.Casting && {
           companyName: user.Casting.companyName,
-          companyId: user.Casting.castingId,
+          companyId: user.Casting.companyId,
           employmentCertUrl: user.Casting.employmentCertUrl,
-        }
-      }
-      if(user.Actor) {
-        aPendingUser = {
-          ...aPendingUser,
+        }),
+        ...(user.Actor && {
           idCardImageUrl: user.Actor.idCardImageUrl,
           ssn: user.Actor.ssn,
-        }
+        }),
       }
-      */
       pendingUsers.push(aPendingUser)
     }
     return pendingUsers

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { Casting, Prisma, User, UserType } from '@modela/database'
+import { Casting, Prisma, User, UserStatus, UserType } from '@modela/database'
 import { PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
@@ -47,30 +47,28 @@ export class UserRepository {
         Casting: true,
         Actor: true,
       },
+      where: {
+        status: UserStatus.PENDING,
+      },
     })
-    const pendingUsers: PendingUserDto[] = []
-    for (let i = 0; i < users.length; i++) {
-      const user = users[i]
-      const aPendingUser = {
-        type: user.Casting ? UserType.CASTING : UserType.ACTOR,
-        data: {
-          userId: user.userId,
-          firstName: user.firstName,
-          middleName: user.middleName,
-          lastName: user.lastName,
-          ...(user.Casting && {
-            companyName: user.Casting.companyName,
-            companyId: user.Casting.companyId,
-            employmentCertUrl: user.Casting.employmentCertUrl,
-          }),
-          ...(user.Actor && {
-            idCardImageUrl: user.Actor.idCardImageUrl,
-            ssn: user.Actor.ssn,
-          }),
-        },
-      }
-      pendingUsers.push(aPendingUser)
-    }
+    const pendingUsers = users.map((user) => ({
+      type: user.Casting ? UserType.CASTING : UserType.ACTOR,
+      data: {
+        userId: user.userId,
+        firstName: user.firstName,
+        middleName: user.middleName,
+        lastName: user.lastName,
+        ...(user.Casting && {
+          companyName: user.Casting.companyName,
+          companyId: user.Casting.companyId,
+          employmentCertUrl: user.Casting.employmentCertUrl,
+        }),
+        ...(user.Actor && {
+          idCardImageUrl: user.Actor.idCardImageUrl,
+          ssn: user.Actor.ssn,
+        }),
+      },
+    }))
     return pendingUsers
   }
 

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { Casting, Prisma, User, UserStatus, UserType } from '@modela/database'
+import { Casting, Prisma, User, UserStatus } from '@modela/database'
 import { PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
@@ -19,27 +19,8 @@ export class UserRepository {
     })
   }
 
-  async getUsers(params: {
-    skip?: number
-    take?: number
-    cursor?: Prisma.UserWhereUniqueInput
-    where?: Prisma.UserWhereInput
-    orderBy?: Prisma.UserOrderByWithRelationInput
-  }): Promise<User[]> {
-    return await this.prisma.user.findMany({
-      ...params,
-    })
-  }
-
-  async getPendingUsers(params: {
-    skip?: number
-    take?: number
-    cursor?: Prisma.UserWhereUniqueInput
-    where?: Prisma.UserWhereInput
-    orderBy?: Prisma.UserOrderByWithRelationInput
-  }): Promise<PendingUserDto[]> {
+  async getPendingUsers(): Promise<PendingUserDto[]> {
     const users = await this.prisma.user.findMany({
-      ...params,
       orderBy: {
         updatedAt: Prisma.SortOrder.asc,
       },
@@ -52,7 +33,7 @@ export class UserRepository {
       },
     })
     const pendingUsers = users.map((user) => ({
-      type: user.Casting ? UserType.CASTING : UserType.ACTOR,
+      type: user.type,
       data: {
         userId: user.userId,
         firstName: user.firstName,

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,5 +1,5 @@
 import { Casting, Prisma, User, UserType } from '@modela/database'
-import { PendingUserDto } from '@modela/dtos'
+import { PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -41,7 +41,7 @@ export class UserRepository {
     const users = await this.prisma.user.findMany({
       ...params,
       orderBy: {
-        userId: Prisma.SortOrder.desc,
+        updatedAt: Prisma.SortOrder.desc,
       },
       include: {
         Casting: true,
@@ -74,12 +74,15 @@ export class UserRepository {
     return pendingUsers
   }
 
-  async updateUserVerification(userId: number): Promise<User> {
+  async updateUserStatus(
+    userId: number,
+    updateUserStatusDto: UpdateUserStatusDto,
+  ): Promise<User> {
     //accept user
     return await this.prisma.user.update({
       where: { userId },
       data: {
-        isVerified: true,
+        status: updateUserStatusDto.status,
       },
     })
   }

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,4 +1,5 @@
-import { Casting, Prisma, User } from '@modela/database'
+import { Casting, Prisma, User, UserType } from '@modela/database'
+import { PendingUserDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -28,6 +29,57 @@ export class UserRepository {
     return await this.prisma.user.findMany({
       ...params,
     })
+  }
+
+  async getPendingUsers(params: {
+    skip?: number
+    take?: number
+    cursor?: Prisma.UserWhereUniqueInput
+    where?: Prisma.UserWhereInput
+    orderBy?: Prisma.UserOrderByWithRelationInput
+  }): Promise<PendingUserDto[]> {
+    const users = await this.prisma.user.findMany({
+      ...params,
+      orderBy: {
+        userId: Prisma.SortOrder.desc,
+      },
+      include: {
+        Casting: true,
+        Actor: true,
+      },
+      //TODO: filter ??????????????????
+    })
+    const pendingUsers: PendingUserDto[] = []
+    for (let i = 0; i < users.length; i++) {
+      const user = users[i]
+      console.log(user)
+      const aPendingUser = {
+        userId: user.userId,
+        firstName: user.firstName,
+        middleName: user.middleName,
+        lastName: user.lastName,
+        type: user.Casting ? UserType.CASTING : UserType.ACTOR, //TODO: does we need to verify admin?
+      }
+      /*
+      if(user.Casting) {
+        aPendingUser = {
+          ...aPendingUser,
+          companyName: user.Casting.companyName,
+          companyId: user.Casting.castingId,
+          employmentCertUrl: user.Casting.employmentCertUrl,
+        }
+      }
+      if(user.Actor) {
+        aPendingUser = {
+          ...aPendingUser,
+          idCardImageUrl: user.Actor.idCardImageUrl,
+          ssn: user.Actor.ssn,
+        }
+      }
+      */
+      pendingUsers.push(aPendingUser)
+    }
+    return pendingUsers
   }
 
   async updateUserVerification(userId: number): Promise<User> {

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -46,19 +46,25 @@ export class UserService {
     //check if user exist
     const user = await this.repository.getUserById(userId)
     if (!user) throw new NotFoundException()
+
     if (user.status !== UserStatus.PENDING)
       throw new BadRequestException('User is not pending')
 
-    //accept user
-    if (updateUserStatusDto.status === UserStatus.ACCEPTED) {
-      const user = await this.repository.updateUserStatus(
-        userId,
-        updateUserStatusDto,
-      )
-      return user
+    if (updateUserStatusDto.status === UserStatus.PENDING)
+      throw new BadRequestException('Cannot set user status to pending')
+
+    if (updateUserStatusDto.status === UserStatus.REJECTED) {
+      if (!updateUserStatusDto.rejectedReason)
+        throw new BadRequestException('Reason is required')
+    } else {
+      //UserStatus.ACCEPTED
+      updateUserStatusDto.rejectedReason = null
     }
-    //TODO : reject user
-    //throw bad request response
-    throw new BadRequestException('Wrong format')
+
+    const updatedUser = await this.repository.updateUserStatus(
+      userId,
+      updateUserStatusDto,
+    )
+    return updatedUser
   }
 }

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,5 +1,10 @@
-import { GetUserDto } from '@modela/dtos'
+import {
+  GetUserDto,
+  UpdateUserVerificationDto,
+  UserUpdateVerificationStatus,
+} from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
+import { BadRequestException } from '@nestjs/common/exceptions'
 
 import { UserRepository } from './user.repository'
 
@@ -28,5 +33,23 @@ export class UserService {
         companyName: company.companyName,
       }
     return userData
+  }
+
+  async updateUserVerification(
+    userId: number,
+    updateUserVerificationDto: UpdateUserVerificationDto,
+  ): Promise<GetUserDto> {
+    //accept user
+    if (
+      updateUserVerificationDto.status === UserUpdateVerificationStatus.ACCEPT
+    ) {
+      const user = await this.repository.updateUserVerification(userId)
+      return user
+    }
+    //TODO : reject user
+    else {
+      //throw bad request response
+      throw new BadRequestException('Wrong format')
+    }
   }
 }

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -56,9 +56,7 @@ export class UserService {
       return user
     }
     //TODO : reject user
-    else {
-      //throw bad request response
-      throw new BadRequestException('Wrong format')
-    }
+    //throw bad request response
+    throw new BadRequestException('Wrong format')
   }
 }

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -4,7 +4,10 @@ import {
   UserUpdateVerificationStatus,
 } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
-import { BadRequestException } from '@nestjs/common/exceptions'
+import {
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common/exceptions'
 
 import { UserRepository } from './user.repository'
 
@@ -39,6 +42,10 @@ export class UserService {
     userId: number,
     updateUserVerificationDto: UpdateUserVerificationDto,
   ): Promise<GetUserDto> {
+    //check if user exist
+    const user = await this.repository.getUserById(userId)
+    if (!user) throw new NotFoundException()
+
     //accept user
     if (
       updateUserVerificationDto.status === UserUpdateVerificationStatus.ACCEPT

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,9 +1,5 @@
-import {
-  GetUserDto,
-  PendingUserDto,
-  UpdateUserVerificationDto,
-  UserUpdateVerificationStatus,
-} from '@modela/dtos'
+import { UserStatus } from '@modela/database'
+import { GetUserDto, PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import {
   BadRequestException,
@@ -43,19 +39,20 @@ export class UserService {
     const users = await this.repository.getPendingUsers({})
     return users
   }
-  async updateUserVerification(
+  async updateUserStatus(
     userId: number,
-    updateUserVerificationDto: UpdateUserVerificationDto,
+    updateUserStatusDto: UpdateUserStatusDto,
   ): Promise<GetUserDto> {
     //check if user exist
     const user = await this.repository.getUserById(userId)
     if (!user) throw new NotFoundException()
 
     //accept user
-    if (
-      updateUserVerificationDto.status === UserUpdateVerificationStatus.ACCEPT
-    ) {
-      const user = await this.repository.updateUserVerification(userId)
+    if (updateUserStatusDto.status === UserStatus.ACCEPTED) {
+      const user = await this.repository.updateUserStatus(
+        userId,
+        updateUserStatusDto,
+      )
       return user
     }
     //TODO : reject user

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -38,6 +38,15 @@ export class UserService {
     return userData
   }
 
+  async getPendingUsers(): Promise<GetUserDto[]> {
+    const params = {
+      where: {
+        isVerified: false,
+      },
+    }
+    const users = await this.repository.getUsers(params)
+    return users
+  }
   async updateUserVerification(
     userId: number,
     updateUserVerificationDto: UpdateUserVerificationDto,

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -36,7 +36,7 @@ export class UserService {
   }
 
   async getPendingUsers(): Promise<PendingUserDto[]> {
-    const users = await this.repository.getPendingUsers({})
+    const users = await this.repository.getPendingUsers()
     return users
   }
   async updateUserStatus(

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,5 +1,6 @@
 import {
   GetUserDto,
+  PendingUserDto,
   UpdateUserVerificationDto,
   UserUpdateVerificationStatus,
 } from '@modela/dtos'
@@ -38,13 +39,8 @@ export class UserService {
     return userData
   }
 
-  async getPendingUsers(): Promise<GetUserDto[]> {
-    const params = {
-      where: {
-        isVerified: false,
-      },
-    }
-    const users = await this.repository.getUsers(params)
+  async getPendingUsers(): Promise<PendingUserDto[]> {
+    const users = await this.repository.getPendingUsers({})
     return users
   }
   async updateUserVerification(

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -46,6 +46,8 @@ export class UserService {
     //check if user exist
     const user = await this.repository.getUserById(userId)
     if (!user) throw new NotFoundException()
+    if (user.status !== UserStatus.PENDING)
+      throw new BadRequestException('User is not pending')
 
     //accept user
     if (updateUserStatusDto.status === UserStatus.ACCEPTED) {

--- a/apps/web/src/common/context/UserContext/hooks/useUserData/index.test.tsx
+++ b/apps/web/src/common/context/UserContext/hooks/useUserData/index.test.tsx
@@ -30,7 +30,7 @@ describe('useUserData()', () => {
     it('should fetch user data correctly', async () => {
       const { result } = renderHook(useUserData)
 
-      expect(getSpy).toBeCalledWith('/user/me')
+      expect(getSpy).toBeCalledWith('/users/me')
 
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       expect(result.current.user).toEqual({ user: MOCK_USER_DATA })

--- a/apps/web/src/common/context/UserContext/hooks/useUserData/index.ts
+++ b/apps/web/src/common/context/UserContext/hooks/useUserData/index.ts
@@ -11,7 +11,7 @@ const useUserData = () => {
 
   const refetch = useCallback(async () => {
     try {
-      const res = await apiClient.get<GetUserDto>('/user/me')
+      const res = await apiClient.get<GetUserDto>('/users/me')
       setUser(res.data)
     } catch (err) {
       if ((err as AxiosError).response?.status !== 401) {

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { Casting, User, UserStatus, UserType } from '@modela/database'
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 export class GetUserDto implements Partial<User & Casting> {
   @ApiProperty()
@@ -25,4 +26,20 @@ export class GetUserDto implements Partial<User & Casting> {
 
   @ApiProperty()
   userId: number
+}
+
+export enum UserUpdateVerificationStatus {
+  'ACCEPT' = 'ACCEPT',
+  'REJECT' = 'REJECT',
+}
+export class UpdateUserVerificationDto {
+  @IsNotEmpty()
+  @IsEnum(UserUpdateVerificationStatus)
+  @ApiProperty({enum: UserUpdateVerificationStatus})
+  status: UserUpdateVerificationStatus
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional()
+  reason?: string
 }

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -44,36 +44,20 @@ export class UpdateUserVerificationDto {
   reason?: string
 }
 
-export class PendingUserDto implements Partial<User & Actor & Casting> {
-  @ApiProperty()
-  userId: number
-
-  @ApiProperty()
-  firstName: string
-
-  @ApiProperty()
-  middleName?: string
-
-  @ApiProperty()
-  lastName: string
-
+export class PendingUserDto {
   @ApiProperty()
   type: UserType
 
-  //casting fields
   @ApiProperty()
-  companyName?: string
-
-  @ApiProperty()
-  companyId?: string;
-
-  @ApiProperty()
-  employmentCertUrl?: string;
-
-  //actor fields
-  @ApiProperty()
-  idCardImageUrl?: string;
-
-  @ApiProperty()
-  ssn?: string;
+  data: {
+    userId: number;
+    firstName: string;
+    middleName?: string;
+    lastName: string;
+    companyName?: string;
+    companyId?: string;
+    employmentCertUrl?: string;
+    idCardImageUrl?: string;
+    ssn?: string;
+  }
 }

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -43,3 +43,37 @@ export class UpdateUserVerificationDto {
   @ApiPropertyOptional()
   reason?: string
 }
+
+export class PendingUserDto implements Partial<User & Actor & Casting> {
+  @ApiProperty()
+  userId: number
+
+  @ApiProperty()
+  firstName: string
+
+  @ApiProperty()
+  middleName?: string
+
+  @ApiProperty()
+  lastName: string
+
+  @ApiProperty()
+  type: UserType
+
+  //casting fields
+  @ApiProperty()
+  companyName?: string
+
+  @ApiProperty()
+  companyId?: string;
+
+  @ApiProperty()
+  employmentCertUrl?: string;
+
+  //actor fields
+  @ApiProperty()
+  idCardImageUrl?: string;
+
+  @ApiProperty()
+  ssn?: string;
+}

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -40,20 +40,39 @@ export class UpdateUserStatusDto {
   rejectedReason?: string
 }
 
+export class pendingUserDataDto{
+  @ApiProperty()
+  userId: number;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  middleName?: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty()
+  companyName?: string;
+
+  @ApiProperty()
+  companyId?: string;
+
+  @ApiProperty()
+  employmentCertUrl?: string;
+
+  @ApiProperty()
+  idCardImageUrl?: string;
+
+  @ApiProperty()
+  ssn?: string;
+}
+
 export class PendingUserDto {
   @ApiProperty()
   type: UserType
 
   @ApiProperty()
-  data: {
-    userId: number;
-    firstName: string;
-    middleName?: string;
-    lastName: string;
-    companyName?: string;
-    companyId?: string;
-    employmentCertUrl?: string;
-    idCardImageUrl?: string;
-    ssn?: string;
-  }
+  data: pendingUserDataDto
 }

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -28,15 +28,11 @@ export class GetUserDto implements Partial<User & Casting> {
   userId: number
 }
 
-export enum UserUpdateVerificationStatus {
-  'ACCEPT' = 'ACCEPT',
-  'REJECT' = 'REJECT',
-}
-export class UpdateUserVerificationDto {
+export class UpdateUserStatusDto {
   @IsNotEmpty()
-  @IsEnum(UserUpdateVerificationStatus)
-  @ApiProperty({enum: UserUpdateVerificationStatus})
-  status: UserUpdateVerificationStatus
+  @IsEnum(UserStatus)
+  @ApiProperty({enum: UserStatus})
+  status: UserStatus
 
   @IsOptional()
   @IsString()

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -40,7 +40,7 @@ export class UpdateUserStatusDto {
   rejectedReason?: string
 }
 
-export class pendingUserDataDto{
+export class PendingUserDataDto{
   @ApiProperty()
   userId: number;
 
@@ -74,5 +74,5 @@ export class PendingUserDto {
   type: UserType
 
   @ApiProperty()
-  data: pendingUserDataDto
+  data: PendingUserDataDto
 }

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -37,7 +37,7 @@ export class UpdateUserStatusDto {
   @IsOptional()
   @IsString()
   @ApiPropertyOptional()
-  reason?: string
+  rejectedReason?: string
 }
 
 export class PendingUserDto {


### PR DESCRIPTION
## What did you do
- add ```PendingUserDto``` and ```UpdateUserStatusDto``` in user Dto
- implement ```GET /users/pending``` to get all users that have PENDING status
- show the oldest first and have essential data for each user type
- implement ```PUT /users/:id/verification``` for update a user status to ACCEPTED, or REJECTED with rejectedReason
- both endpoints need to be admin only to access, else will be a Forbidden response.


## Demo
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login 
- login with email: ```admin1@gmail.com``` and password: ```password```
- https://api-dev.modela.miello.dev/swagger#/users/UserController_getUserData
- get pending users to inspect all users that have PENDING status
- https://api-dev.modela.miello.dev/swagger#/users/UserController_updateUserStatus
- choose userId to ACCEPTED, or REJECTED with rejectedReason, recheck again in get pending users

- (if not have PENDING users, open a separate session to signup)
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_signupActor
- signup with
  ```
    {
      "email": "actor.number@gmail.com",
      "password": "password",
      "firstName": "firstName",
      "middleName": "middleName",
      "lastName": "lastName",
      "prefix": "mr",
      "nationality": "nationality",
      "ssn": "string",
      "gender": "MALE",
      "phoneNumber": "0987654321",
      "idCardImageUrl": "card.png"
    }
  ```
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_signupCasting
- signup with
  ```
    {
      "email": "casting.number@gmail.com",
      "password": "password",
      "firstName": "firstName",
      "middleName": "middleName",
      "lastName": "lastName",
      "companyId": "0123456789123",
      "companyName": "myCompany",
      "employmentCertUrl": "cert.png"
    }
  ```

## Limitation
- not have unit test yet
