### PR TITLE
[89] Implement casting profile edit page

### DIFF
--- a/apps/web/src/common/components/FormController/components/UploadFile/index.tsx
+++ b/apps/web/src/common/components/FormController/components/UploadFile/index.tsx
@@ -7,7 +7,7 @@ import { UploadFileContainer } from './styled'
 import { IUploadFileProps } from './types'
 
 const UploadFile: FC<IUploadFileProps> = (props) => {
-  const { error, url, errorMessage, handleSelectFile, label } = props
+  const { error, url, errorMessage, handleSelectFile, label, hideLink } = props
   const { handleUploadFile, name, removeSameFile } =
     useUploadFile(handleSelectFile)
 
@@ -38,7 +38,7 @@ const UploadFile: FC<IUploadFileProps> = (props) => {
           {errorMessage}
         </Typography>
       )}
-      {name && !error && (
+      {name && !hideLink && !error && (
         <Typography sx={{ textAlign: 'center' }} variant="subtitle2">
           <Link
             href={url}

--- a/apps/web/src/common/components/FormController/components/UploadFile/types.ts
+++ b/apps/web/src/common/components/FormController/components/UploadFile/types.ts
@@ -4,4 +4,5 @@ export interface IUploadFileProps {
   handleSelectFile: (file: Blob) => void
   label?: string
   url?: string
+  hideLink?: boolean
 }

--- a/apps/web/src/common/components/FormController/index.test.tsx
+++ b/apps/web/src/common/components/FormController/index.test.tsx
@@ -92,15 +92,7 @@ describe('FormController', () => {
   })
   test('should render Divider if type is divider', () => {
     const { default: FormController } = require('.') as typeof import('.')
-    render(
-      <FormController
-        label="Hello"
-        fullWidth={false}
-        sm={12}
-        xs={12}
-        type="divider"
-      />,
-    )
+    render(<FormController sm={12} xs={12} type="divider" />)
 
     expect(mockDivider).toBeCalled()
   })

--- a/apps/web/src/common/components/FormController/index.tsx
+++ b/apps/web/src/common/components/FormController/index.tsx
@@ -32,7 +32,7 @@ const FormController = <T extends FieldValues>(
               return (
                 <TextField
                   required={!props.optional}
-                  fullWidth={props.fullWidth}
+                  fullWidth={props.fullWidth ?? true}
                   label={props.label}
                   inputRef={ref}
                   {...field}
@@ -45,7 +45,7 @@ const FormController = <T extends FieldValues>(
               return (
                 <TextField
                   required={!props.optional}
-                  fullWidth={props.fullWidth}
+                  fullWidth={props.fullWidth ?? true}
                   label={props.label}
                   inputRef={ref}
                   {...field}
@@ -80,7 +80,7 @@ const FormController = <T extends FieldValues>(
                 <TextField
                   select
                   required={!props.optional}
-                  fullWidth={props.fullWidth}
+                  fullWidth={props.fullWidth ?? true}
                   label={props.label}
                   inputRef={ref}
                   {...field}
@@ -136,7 +136,7 @@ const FormController = <T extends FieldValues>(
             return (
               <PasswordTextField
                 required={!props.optional}
-                fullWidth={props.fullWidth}
+                fullWidth={props.fullWidth ?? true}
                 label={props.label}
                 {...field}
                 inputRef={ref}

--- a/apps/web/src/common/components/FormController/index.tsx
+++ b/apps/web/src/common/components/FormController/index.tsx
@@ -23,16 +23,19 @@ const FormController = <T extends FieldValues>(
     optional,
     selectProps,
     inputProps,
+    hideLink = false,
   } = props
 
   return (
     <Grid item xs={xs} sm={sm}>
       {type === 'divider' ? (
         <Divider />
-      ) : type === 'typography' ? (
+      ) : type === 'title' ? (
         <Typography variant="h5" sx={{ textAlign: 'center' }}>
           {label}
         </Typography>
+      ) : type === 'label' ? (
+        <Typography>{label}</Typography>
       ) : (
         <Controller
           name={name!}
@@ -77,6 +80,7 @@ const FormController = <T extends FieldValues>(
               return (
                 <UploadFile
                   label={label}
+                  hideLink={hideLink}
                   handleSelectFile={handleUploadFile!}
                   error={props.fieldState.invalid}
                   errorMessage={props.fieldState.error?.message}

--- a/apps/web/src/common/components/FormController/index.tsx
+++ b/apps/web/src/common/components/FormController/index.tsx
@@ -11,20 +11,7 @@ import { IFormControllerProps } from './types'
 const FormController = <T extends FieldValues>(
   props: IFormControllerProps<T>,
 ) => {
-  const {
-    type,
-    xs = 12,
-    sm = 12,
-    control,
-    name,
-    handleUploadFile,
-    fullWidth = true,
-    label,
-    optional,
-    selectProps,
-    inputProps,
-    hideLink = false,
-  } = props
+  const { type, xs = 12, sm = 12 } = props
 
   return (
     <Grid item xs={xs} sm={sm}>
@@ -32,38 +19,38 @@ const FormController = <T extends FieldValues>(
         <Divider />
       ) : type === 'title' ? (
         <Typography variant="h5" sx={{ textAlign: 'center' }}>
-          {label}
+          {props.label}
         </Typography>
       ) : type === 'label' ? (
-        <Typography>{label}</Typography>
+        <Typography>{props.label}</Typography>
       ) : (
         <Controller
-          name={name!}
-          control={control}
-          render={({ field: { ref, ...field }, ...props }) => {
+          name={props.name!}
+          control={props.control}
+          render={({ field: { ref, ...field }, ...formProps }) => {
             if (type === 'textField')
               return (
                 <TextField
-                  required={!optional}
-                  fullWidth={fullWidth}
-                  label={label}
+                  required={!props.optional}
+                  fullWidth={props.fullWidth}
+                  label={props.label}
                   inputRef={ref}
                   {...field}
-                  error={props.fieldState.invalid}
-                  helperText={props.fieldState.error?.message}
-                  {...inputProps}
+                  error={formProps.fieldState.invalid}
+                  helperText={formProps.fieldState.error?.message}
+                  {...props.inputProps}
                 />
               )
             if (type === 'number')
               return (
                 <TextField
-                  required={!optional}
-                  fullWidth={fullWidth}
-                  label={label}
+                  required={!props.optional}
+                  fullWidth={props.fullWidth}
+                  label={props.label}
                   inputRef={ref}
                   {...field}
-                  error={props.fieldState.invalid}
-                  helperText={props.fieldState.error?.message}
+                  error={formProps.fieldState.invalid}
+                  helperText={formProps.fieldState.error?.message}
                   onChange={(event) =>
                     field.onChange(
                       event.target.value === '' ? '' : +event.target.value,
@@ -71,21 +58,20 @@ const FormController = <T extends FieldValues>(
                   }
                   type="number"
                   InputProps={{
-                    inputProps,
+                    inputProps: props.inputProps,
                   }}
-                  {...inputProps}
+                  {...props.inputProps}
                 />
               )
             if (type === 'uploadFile')
               return (
                 <UploadFile
-                  label={label}
-                  hideLink={hideLink}
-                  handleSelectFile={handleUploadFile!}
-                  error={props.fieldState.invalid}
-                  errorMessage={props.fieldState.error?.message}
+                  label={props.label}
+                  hideLink={props.hideLink}
+                  handleSelectFile={props.handleUploadFile!}
+                  error={formProps.fieldState.invalid}
+                  errorMessage={formProps.fieldState.error?.message}
                   url={field.value}
-                  {...inputProps}
                 />
               )
 
@@ -93,16 +79,16 @@ const FormController = <T extends FieldValues>(
               return (
                 <TextField
                   select
-                  required={!optional}
-                  fullWidth={fullWidth}
-                  label={label}
+                  required={!props.optional}
+                  fullWidth={props.fullWidth}
+                  label={props.label}
                   inputRef={ref}
                   {...field}
-                  error={props.fieldState.invalid}
-                  helperText={props.fieldState.error?.message}
-                  {...inputProps}
+                  error={formProps.fieldState.invalid}
+                  helperText={formProps.fieldState.error?.message}
+                  {...props.inputProps}
                 >
-                  {selectProps?.map((choice) => (
+                  {props.selectProps?.map((choice) => (
                     <MenuItem
                       {...choice}
                       key={choice.value?.toString() || `${Math.random()}`}
@@ -113,7 +99,7 @@ const FormController = <T extends FieldValues>(
             if (type === 'date')
               return (
                 <DesktopDatePicker
-                  label={label}
+                  label={props.label}
                   inputFormat="DD/MM/YYYY"
                   inputRef={ref}
                   {...field}
@@ -122,8 +108,8 @@ const FormController = <T extends FieldValues>(
                     <TextField
                       {...params}
                       fullWidth
-                      error={props.fieldState.invalid}
-                      helperText={props.fieldState.error?.message}
+                      error={formProps.fieldState.invalid}
+                      helperText={formProps.fieldState.error?.message}
                     />
                   )}
                 />
@@ -131,7 +117,7 @@ const FormController = <T extends FieldValues>(
             if (type === 'time')
               return (
                 <TimePicker
-                  label={label}
+                  label={props.label}
                   ampm={false}
                   inputRef={ref}
                   {...field}
@@ -140,8 +126,8 @@ const FormController = <T extends FieldValues>(
                     <TextField
                       {...params}
                       fullWidth
-                      error={props.fieldState.invalid}
-                      helperText={props.fieldState.error?.message}
+                      error={formProps.fieldState.invalid}
+                      helperText={formProps.fieldState.error?.message}
                     />
                   )}
                 />
@@ -149,14 +135,14 @@ const FormController = <T extends FieldValues>(
 
             return (
               <PasswordTextField
-                required={!optional}
-                fullWidth={fullWidth}
-                label={label}
+                required={!props.optional}
+                fullWidth={props.fullWidth}
+                label={props.label}
                 {...field}
                 inputRef={ref}
-                error={props.fieldState.invalid}
-                helperText={props.fieldState.error?.message}
-                {...inputProps}
+                error={formProps.fieldState.invalid}
+                helperText={formProps.fieldState.error?.message}
+                {...props.inputProps}
               />
             )
           }}

--- a/apps/web/src/common/components/FormController/types.ts
+++ b/apps/web/src/common/components/FormController/types.ts
@@ -1,27 +1,88 @@
 import { MenuItemProps } from '@mui/material'
 import { Control, FieldValues, Path } from 'react-hook-form'
 
-export interface IFormControllerProps<T extends FieldValues> {
-  type:
-    | 'textField'
-    | 'number'
-    | 'uploadFile'
-    | 'divider'
-    | 'password'
-    | 'select'
-    | 'date'
-    | 'time'
-    | 'title'
-    | 'label'
+export type IFormControllerProps<T extends FieldValues> = {
+  control?: Control<T>
+  handleUploadFile?(file: Blob): void
+} & (
+  | IDivider
+  | ITitle
+  | ILabel
+  | ITextField<T>
+  | IDateField<T>
+  | INumberTextField<T>
+  | IUploadFileField<T>
+  | ISelectField<T>
+  | IDateField<T>
+  | ITimeField<T>
+  | IPasswordField<T>
+)
+
+interface IDivider {
+  type: 'divider'
   xs?: number
   sm?: number
-  name?: Path<T>
+}
+
+interface ITitle {
+  type: 'title'
   label?: string
-  control?: Control<T>
+  xs?: number
+  sm?: number
+}
+
+interface ILabel {
+  type: 'label'
+  label?: string
+  xs?: number
+  sm?: number
+}
+
+interface ITextField<T extends FieldValues> {
+  type: 'textField'
+  xs?: number
+  sm?: number
   optional?: boolean
-  fullWidth?: boolean
-  hideLink?: boolean
-  selectProps?: MenuItemProps[]
-  handleUploadFile?(file: Blob): void
   inputProps?: { [key: string]: any }
+  fullWidth?: boolean
+  name: Path<T>
+  label?: string
+}
+
+interface INumberTextField<T extends FieldValues>
+  extends Omit<ITextField<T>, 'type'> {
+  type: 'number'
+}
+
+interface IUploadFileField<T extends FieldValues> {
+  type: 'uploadFile'
+  xs?: number
+  sm?: number
+  name: Path<T>
+  label?: string
+  hideLink?: boolean
+}
+
+interface ISelectField<T extends FieldValues>
+  extends Omit<ITextField<T>, 'type'> {
+  type: 'select'
+  selectProps?: MenuItemProps[]
+}
+
+interface IDateField<T extends FieldValues> {
+  type: 'date'
+  label?: string
+  xs?: number
+  sm?: number
+  name: Path<T>
+}
+
+interface ITimeField<T extends FieldValues>
+  extends Omit<IDateField<T>, 'type'> {
+  type: 'time'
+}
+
+interface IPasswordField<T extends FieldValues>
+  extends Omit<ITextField<T>, 'type'> {
+  type: 'password'
 }

--- a/apps/web/src/common/components/FormController/types.ts
+++ b/apps/web/src/common/components/FormController/types.ts
@@ -11,7 +11,8 @@ export interface IFormControllerProps<T extends FieldValues> {
     | 'select'
     | 'date'
     | 'time'
-    | 'typography'
+    | 'title'
+    | 'label'
   xs?: number
   sm?: number
   name?: Path<T>
@@ -19,6 +20,7 @@ export interface IFormControllerProps<T extends FieldValues> {
   control?: Control<T>
   optional?: boolean
   fullWidth?: boolean
+  hideLink?: boolean
   selectProps?: MenuItemProps[]
   handleUploadFile?(file: Blob): void
   inputProps?: { [key: string]: any }

--- a/apps/web/src/modules/job/components/JobForm/components/ShootingForm/constant.ts
+++ b/apps/web/src/modules/job/components/JobForm/components/ShootingForm/constant.ts
@@ -4,7 +4,7 @@ import { IPostJobSchemaType } from '../../hooks/useJobForm/schema'
 
 export const formLayout = (
   index: number,
-): Omit<IFormControllerProps<IPostJobSchemaType>, 'control'>[] => [
+): IFormControllerProps<IPostJobSchemaType>[] => [
   {
     type: 'textField',
     label: 'สถานที่ถ่ายทำ',

--- a/apps/web/src/modules/job/components/JobForm/components/ShootingForm/index.tsx
+++ b/apps/web/src/modules/job/components/JobForm/components/ShootingForm/index.tsx
@@ -2,7 +2,6 @@ import { Remove } from '@mui/icons-material'
 import { Grid, Typography } from '@mui/material'
 import FormController from 'common/components/FormController'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { formLayout } from './constant'
 import { ShootingFormProps } from './types'
@@ -27,7 +26,7 @@ const ShootingForm = (prop: ShootingFormProps) => {
       </Grid>
       {formLayout(index).map((props) => (
         <FormController
-          control={control as unknown as Control<FieldValues>}
+          control={control as any}
           key={JSON.stringify(props)}
           {...props}
         />

--- a/apps/web/src/modules/job/components/JobForm/constant.ts
+++ b/apps/web/src/modules/job/components/JobForm/constant.ts
@@ -29,7 +29,7 @@ export const FORM_LAYOUT:
       | Omit<IFormControllerProps<IPostJobSchemaType>, 'control'>
       | { type: 'shooting' }
     )[] = [
-  { type: 'typography', label: 'รายละเอียดงาน' },
+  { type: 'title', label: 'รายละเอียดงาน' },
   {
     type: 'textField',
     label: 'ชื่องาน',
@@ -65,7 +65,7 @@ export const FORM_LAYOUT:
     type: 'shooting',
   },
   {
-    type: 'typography',
+    type: 'title',
     label: 'รายละเอียดนักแสดง',
   },
   {

--- a/apps/web/src/modules/job/components/JobForm/constant.ts
+++ b/apps/web/src/modules/job/components/JobForm/constant.ts
@@ -25,10 +25,7 @@ export const GENDER_CHOICE: MenuItemProps[] = [
 ]
 
 export const FORM_LAYOUT:
-  | (
-      | Omit<IFormControllerProps<IPostJobSchemaType>, 'control'>
-      | { type: 'shooting' }
-    )[] = [
+  | (IFormControllerProps<IPostJobSchemaType> | { type: 'shooting' })[] = [
   { type: 'title', label: 'รายละเอียดงาน' },
   {
     type: 'textField',

--- a/apps/web/src/modules/job/components/JobForm/index.tsx
+++ b/apps/web/src/modules/job/components/JobForm/index.tsx
@@ -1,7 +1,6 @@
 import { Grid } from '@mui/material'
 import FormController from 'common/components/FormController'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import AddShootingButton from './components/AddShootingButton'
 import ShootingForm from './components/ShootingForm'
@@ -43,7 +42,7 @@ const PostJobPage = ({ edit, initialValues }: JobFormProps) => {
               )
             return (
               <FormController
-                control={control as unknown as Control<FieldValues>}
+                control={control as any}
                 key={JSON.stringify(props)}
                 {...props}
               />

--- a/apps/web/src/modules/login/constants.ts
+++ b/apps/web/src/modules/login/constants.ts
@@ -2,10 +2,7 @@ import { IFormControllerProps } from 'common/components/FormController/types'
 
 import { ILoginSchemaType } from './hooks/useLoginForm/schema'
 
-export const FORM_LAYOUT: Omit<
-  IFormControllerProps<ILoginSchemaType>,
-  'control'
->[] = [
+export const FORM_LAYOUT: IFormControllerProps<ILoginSchemaType>[] = [
   {
     type: 'divider',
   },

--- a/apps/web/src/modules/login/index.tsx
+++ b/apps/web/src/modules/login/index.tsx
@@ -3,7 +3,6 @@ import FormController from 'common/components/FormController'
 import withGuard from 'common/hoc/withGuard'
 import Link from 'next/link'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { FORM_LAYOUT } from './constants'
 import useLoginForm from './hooks/useLoginForm'
@@ -27,7 +26,7 @@ const Login = () => {
           {FORM_LAYOUT.map((props) => (
             <FormController
               // I do not know why I cannot directly pass control
-              control={control as unknown as Control<FieldValues>}
+              control={control as any}
               key={JSON.stringify(props)}
               {...props}
             />

--- a/apps/web/src/modules/profile/edit/casting/constants.ts
+++ b/apps/web/src/modules/profile/edit/casting/constants.ts
@@ -29,7 +29,6 @@ export const FORM_LAYOUT: IFormControllerProps<IEditCastingProfileSchemaType>[] 
     },
     {
       type: 'textField',
-      fullWidth: true,
       label: 'เบอร์โทรศัพท์',
       name: 'phoneNumber',
       optional: true,
@@ -38,7 +37,6 @@ export const FORM_LAYOUT: IFormControllerProps<IEditCastingProfileSchemaType>[] 
     },
     {
       type: 'textField',
-      fullWidth: true,
       label: 'ข้อมูลอื่น ๆ',
       name: 'description',
       optional: true,

--- a/apps/web/src/modules/profile/edit/casting/constants.ts
+++ b/apps/web/src/modules/profile/edit/casting/constants.ts
@@ -2,74 +2,71 @@ import { IFormControllerProps } from 'common/components/FormController/types'
 
 import { IEditCastingProfileSchemaType } from './hooks/useEditCastingForm/schema'
 
-export const FORM_LAYOUT: Omit<
-  IFormControllerProps<IEditCastingProfileSchemaType>,
-  'control'
->[] = [
-  {
-    type: 'title',
-    label: 'แก้ไขโปรไฟล์',
-    sm: 12,
-    xs: 12,
-  },
-  {
-    type: 'divider',
-    sm: 12,
-    xs: 12,
-  },
-  {
-    type: 'uploadFile',
-    label: 'อัปโหลดรูปโปรไฟล์',
-    hideLink: true,
-    name: 'profileImageUrl',
-    sm: 12,
-    xs: 12,
-  },
-  {
-    type: 'label',
-    label: 'ข้อมูลส่วนตัว',
-    fullWidth: true,
-  },
-  {
-    type: 'textField',
-    fullWidth: true,
-    label: 'เบอร์โทรศัพท์',
-    name: 'phoneNumber',
-    optional: true,
-    sm: 12,
-    xs: 12,
-  },
-  {
-    type: 'textField',
-    fullWidth: true,
-    label: 'ข้อมูลอื่น ๆ',
-    name: 'description',
-    optional: true,
-    sm: 12,
-    xs: 12,
-    inputProps: {
-      multiline: true,
-      rows: 3,
+export const FORM_LAYOUT: IFormControllerProps<IEditCastingProfileSchemaType>[] =
+  [
+    {
+      type: 'title',
+      label: 'แก้ไขโปรไฟล์',
+      sm: 12,
+      xs: 12,
     },
-  },
-  {
-    type: 'label',
-    label: 'ข้อมูลธุรกรรม',
-  },
-  {
-    type: 'textField',
-    label: 'ชื่อธนาคารของบัญชี',
-    optional: true,
-    name: 'bankName',
-    sm: 6,
-    xs: 12,
-  },
-  {
-    type: 'textField',
-    label: 'เลขบัญชี',
-    name: 'bankAccount',
-    optional: true,
-    sm: 6,
-    xs: 12,
-  },
-]
+    {
+      type: 'divider',
+      sm: 12,
+      xs: 12,
+    },
+    {
+      type: 'uploadFile',
+      label: 'อัปโหลดรูปโปรไฟล์',
+      hideLink: true,
+      name: 'profileImageUrl',
+      sm: 12,
+      xs: 12,
+    },
+    {
+      type: 'label',
+      label: 'ข้อมูลส่วนตัว',
+    },
+    {
+      type: 'textField',
+      fullWidth: true,
+      label: 'เบอร์โทรศัพท์',
+      name: 'phoneNumber',
+      optional: true,
+      sm: 12,
+      xs: 12,
+    },
+    {
+      type: 'textField',
+      fullWidth: true,
+      label: 'ข้อมูลอื่น ๆ',
+      name: 'description',
+      optional: true,
+      sm: 12,
+      xs: 12,
+      inputProps: {
+        multiline: true,
+        rows: 3,
+      },
+    },
+    {
+      type: 'label',
+      label: 'ข้อมูลธุรกรรม',
+    },
+    {
+      type: 'textField',
+      label: 'ชื่อธนาคารของบัญชี',
+      optional: true,
+      name: 'bankName',
+      sm: 6,
+      xs: 12,
+    },
+    {
+      type: 'textField',
+      label: 'เลขบัญชี',
+      name: 'bankAccount',
+      optional: true,
+      sm: 6,
+      xs: 12,
+    },
+  ]

--- a/apps/web/src/modules/profile/edit/casting/constants.ts
+++ b/apps/web/src/modules/profile/edit/casting/constants.ts
@@ -1,0 +1,75 @@
+import { IFormControllerProps } from 'common/components/FormController/types'
+
+import { IEditCastingProfileSchemaType } from './hooks/useEditCastingForm/schema'
+
+export const FORM_LAYOUT: Omit<
+  IFormControllerProps<IEditCastingProfileSchemaType>,
+  'control'
+>[] = [
+  {
+    type: 'title',
+    label: 'แก้ไขโปรไฟล์',
+    sm: 12,
+    xs: 12,
+  },
+  {
+    type: 'divider',
+    sm: 12,
+    xs: 12,
+  },
+  {
+    type: 'uploadFile',
+    label: 'อัปโหลดรูปโปรไฟล์',
+    hideLink: true,
+    name: 'profileImageUrl',
+    sm: 12,
+    xs: 12,
+  },
+  {
+    type: 'label',
+    label: 'ข้อมูลส่วนตัว',
+    fullWidth: true,
+  },
+  {
+    type: 'textField',
+    fullWidth: true,
+    label: 'เบอร์โทรศัพท์',
+    name: 'phoneNumber',
+    optional: true,
+    sm: 12,
+    xs: 12,
+  },
+  {
+    type: 'textField',
+    fullWidth: true,
+    label: 'ข้อมูลอื่น ๆ',
+    name: 'description',
+    optional: true,
+    sm: 12,
+    xs: 12,
+    inputProps: {
+      multiline: true,
+      rows: 3,
+    },
+  },
+  {
+    type: 'label',
+    label: 'ข้อมูลธุรกรรม',
+  },
+  {
+    type: 'textField',
+    label: 'ชื่อธนาคารของบัญชี',
+    optional: true,
+    name: 'bankName',
+    sm: 6,
+    xs: 12,
+  },
+  {
+    type: 'textField',
+    label: 'เลขบัญชี',
+    name: 'bankAccount',
+    optional: true,
+    sm: 6,
+    xs: 12,
+  },
+]

--- a/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { EditCastingProfileDto } from '@modela/dtos'
+import { useUser } from 'common/context/UserContext'
 import { useErrorHandler } from 'common/hooks/useErrorHandler'
 import { apiClient } from 'common/utils/api'
 import { useRouter } from 'next/router'
@@ -26,6 +27,7 @@ const useEditCastingForm = () => {
   const [loading, setLoading] = useState(false)
   const [isDataLoading, setDataLoading] = useState(true)
   const { handleError } = useErrorHandler()
+  const { user } = useUser()
 
   const handleSuccess: SubmitHandler<IEditCastingProfileSchemaType> =
     useCallback(
@@ -86,7 +88,8 @@ const useEditCastingForm = () => {
     getValues,
     control,
     isDataLoading,
-    imageUrl: getValues('profileImageUrl'),
+    user,
+    imageUrl: getValues('profileImageUrl') || user?.profileImageUrl,
   }
 }
 

--- a/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
@@ -1,0 +1,75 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { EditCastingProfileDto } from '@modela/dtos'
+import { useUser } from 'common/context/UserContext'
+import { useErrorHandler } from 'common/hooks/useErrorHandler'
+import { apiClient } from 'common/utils/api'
+import { useRouter } from 'next/router'
+import { FormEventHandler, useCallback, useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import {
+  EditCastingProfileSchema,
+  IEditCastingProfileSchemaType,
+} from './schema'
+
+const useEditCastingForm = () => {
+  const router = useRouter()
+  const { refetch } = useUser()
+
+  const { handleSubmit, setValue, getValues, control } =
+    useForm<IEditCastingProfileSchemaType>({
+      criteriaMode: 'all',
+      resolver: zodResolver(EditCastingProfileSchema),
+    })
+
+  const [, setProfileImage] = useState<Blob | null>(null)
+  const [loading, setLoading] = useState(false)
+  const { handleError } = useErrorHandler()
+
+  const handleSuccess: SubmitHandler<IEditCastingProfileSchemaType> =
+    useCallback(
+      async (data) => {
+        setLoading(true)
+        try {
+          await apiClient.put<unknown, unknown, EditCastingProfileDto>(
+            '/profile/casting',
+            { ...data, profileImageUrl: '' },
+          )
+          await refetch()
+          router.push('/profile')
+        } catch (err) {
+          handleError(err)
+        } finally {
+          setLoading(false)
+        }
+      },
+      [handleError, refetch, router],
+    )
+
+  const handleClickSubmit: FormEventHandler<HTMLFormElement> =
+    handleSubmit(handleSuccess)
+
+  const handleUploadImage = useCallback(
+    (file: Blob) => {
+      URL.revokeObjectURL(getValues('profileImageUrl') || '')
+      const blobUrl = URL.createObjectURL(file)
+
+      setProfileImage(file)
+      setValue('profileImageUrl', blobUrl, {
+        shouldValidate: true,
+      })
+    },
+    [getValues, setValue],
+  )
+
+  return {
+    loading,
+    handleClickSubmit,
+    handleUploadImage,
+    getValues,
+    control,
+    imageUrl: getValues('profileImageUrl'),
+  }
+}
+
+export default useEditCastingForm

--- a/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/index.tsx
@@ -24,6 +24,7 @@ const useEditCastingForm = () => {
 
   const [, setProfileImage] = useState<Blob | null>(null)
   const [loading, setLoading] = useState(false)
+  const [isDataLoading, setDataLoading] = useState(true)
   const { handleError } = useErrorHandler()
 
   const handleSuccess: SubmitHandler<IEditCastingProfileSchemaType> =
@@ -61,16 +62,22 @@ const useEditCastingForm = () => {
     [getValues, setValue],
   )
 
-  useEffect(() => {
-    const getInitialValue = async () => {
+  const getInitialValue = useCallback(async () => {
+    try {
       const res = (
         await apiClient.get<{ data: EditCastingProfileDto }>('/profile')
       ).data
       reset(res.data)
+    } catch (err) {
+      handleError(err)
+    } finally {
+      setDataLoading(false)
     }
+  }, [reset, handleError])
 
+  useEffect(() => {
     getInitialValue()
-  }, [reset])
+  }, [getInitialValue])
 
   return {
     loading,
@@ -78,6 +85,7 @@ const useEditCastingForm = () => {
     handleUploadImage,
     getValues,
     control,
+    isDataLoading,
     imageUrl: getValues('profileImageUrl'),
   }
 }

--- a/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/schema.ts
+++ b/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+const EditCastingProfileSchema = z.object({
+  description: z.optional(z.string()),
+  bankAccount: z.string({
+    required_error: 'กรุณากรอกเลขบัญชี',
+  }),
+  profileImageUrl: z.optional(z.string().url('รูปแบบไม่ถูกต้อง')),
+  bankName: z.optional(z.string()),
+  phoneNumber: z.optional(
+    z
+      .string()
+      .refine(
+        (arg) => /^((\+66)|0)((2[0-9]{7})|([3-9][0-9]{8}))$/.test(arg),
+        'รูปแบบเบอร์โทรศัพท์ไม่ถูกต้อง',
+      ),
+  ),
+})
+
+export type IEditCastingProfileSchemaType = z.infer<
+  typeof EditCastingProfileSchema
+>
+export { EditCastingProfileSchema }

--- a/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/schema.ts
+++ b/apps/web/src/modules/profile/edit/casting/hooks/useEditCastingForm/schema.ts
@@ -17,7 +17,15 @@ const EditCastingProfileSchema = z.object({
   ),
 })
 
+const EditCastingProfileDefault = {
+  bankAccount: '',
+  bankName: '',
+  description: '',
+  phoneNumber: '',
+  profileImageUrl: '',
+}
+
 export type IEditCastingProfileSchemaType = z.infer<
   typeof EditCastingProfileSchema
 >
-export { EditCastingProfileSchema }
+export { EditCastingProfileDefault, EditCastingProfileSchema }

--- a/apps/web/src/modules/profile/edit/casting/index.test.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.test.tsx
@@ -12,6 +12,11 @@ describe('<EditCastingProfile />', () => {
     handleClickSubmit: handleClickSubmitMock,
     control: {},
     imageUrl: '',
+    user: {
+      userId: 123,
+      firstName: 'asd',
+      profileImageUrl: 'asdsa',
+    },
     isDataLoading: false,
     handleUploadImage: jest.fn(),
     loading: false,

--- a/apps/web/src/modules/profile/edit/casting/index.test.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/react'
+import { mockAndSpy, mockAndSpyMany } from 'common/utils/testing'
+
+import { FORM_LAYOUT } from './constants'
+
+describe('<EditCastingProfile />', () => {
+  const FormControllerSpy = mockAndSpy('common/components/FormController')
+  FormControllerSpy.mockImplementation(() => {})
+
+  const handleClickSubmitMock = jest.fn()
+  const BASE_MOCK_HOOK = {
+    handleClickSubmit: handleClickSubmitMock,
+    control: {},
+    imageUrl: '',
+    isDataLoading: false,
+    handleUploadImage: jest.fn(),
+    loading: false,
+  }
+  const editCastingFormMock = jest.fn(() => BASE_MOCK_HOOK)
+
+  jest.doMock('./hooks/useEditCastingForm', () => editCastingFormMock)
+
+  const [CircularProgressSpy] = mockAndSpyMany('@mui/material', [
+    'CircularProgress',
+  ])
+  CircularProgressSpy.mockImplementation(() => {})
+  const { default: EditCastingProfile } = require('.') as typeof import('.')
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should be defined', () => {
+    expect(EditCastingProfile).toBeDefined()
+  })
+
+  describe('while data fetching', () => {
+    test('should render loading', () => {
+      editCastingFormMock.mockReturnValueOnce({
+        ...BASE_MOCK_HOOK,
+        isDataLoading: true,
+      })
+
+      const { queryByText } = render(<EditCastingProfile />)
+      expect(queryByText('บันทึกข้อมูล')).toBeNull()
+      expect(CircularProgressSpy).toBeCalledTimes(1)
+    })
+  })
+
+  describe('when data fetching finish', () => {
+    test('should render form', async () => {
+      const { queryByText } = render(<EditCastingProfile />)
+      FORM_LAYOUT.forEach((val) => {
+        if (!(val as any).label) return
+        expect(queryByText((val as any).label)).toBeDefined()
+      })
+
+      expect(queryByText('บันทึกข้อมูล')).toBeDefined()
+      expect(CircularProgressSpy).toBeCalledTimes(0)
+    })
+
+    test('should trigger handleClickSubmit when submit', () => {
+      const { getByText } = render(<EditCastingProfile />)
+      const el = getByText('บันทึกข้อมูล')
+
+      expect(handleClickSubmitMock).toBeCalledTimes(0)
+
+      fireEvent.submit(el)
+      expect(handleClickSubmitMock).toBeCalledTimes(1)
+    })
+  })
+})

--- a/apps/web/src/modules/profile/edit/casting/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.tsx
@@ -15,6 +15,7 @@ const EditCastingProfile = () => {
     isDataLoading,
     handleUploadImage,
     loading,
+    user,
   } = useEditCastingForm()
 
   return (
@@ -30,8 +31,8 @@ const EditCastingProfile = () => {
                   <Grid item width="100%">
                     <ProfileImage
                       src={imageUrl}
-                      userId={123}
-                      firstName="hello"
+                      userId={user!.userId}
+                      firstName={user!.firstName}
                       sx={{
                         margin: 'auto',
                         width: '150px',

--- a/apps/web/src/modules/profile/edit/casting/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.tsx
@@ -1,0 +1,63 @@
+import { Button, CircularProgress, Grid } from '@mui/material'
+import FormController from 'common/components/FormController'
+import ProfileImage from 'common/components/ProfileImage'
+import { Fragment } from 'react'
+import { Control, FieldValues } from 'react-hook-form'
+
+import { FORM_LAYOUT } from './constants'
+import useEditCastingForm from './hooks/useEditCastingForm'
+import { CardContainer } from './styled'
+
+const EditCastingProfile = () => {
+  const { handleClickSubmit, control, imageUrl, handleUploadImage, loading } =
+    useEditCastingForm()
+
+  return (
+    <CardContainer variant="outlined">
+      <form onSubmit={handleClickSubmit}>
+        <Grid container spacing={2} sx={{ padding: '12px' }}>
+          {FORM_LAYOUT.map((props) => (
+            <Fragment key={JSON.stringify(props)}>
+              {props.type === 'uploadFile' && (
+                <Grid item width="100%">
+                  <ProfileImage
+                    src={imageUrl}
+                    userId={123}
+                    firstName="hello"
+                    sx={{
+                      margin: 'auto',
+                      width: '150px',
+                      height: '150px',
+                    }}
+                  />
+                </Grid>
+              )}
+              <FormController
+                // I do not know why I cannot directly pass control
+                control={control as unknown as Control<FieldValues>}
+                handleUploadFile={handleUploadImage}
+                {...props}
+              />
+            </Fragment>
+          ))}
+          <Grid item width="100%" display="flex" justifyContent="center">
+            <Button
+              sx={{ borderRadius: '12px' }}
+              size="large"
+              variant="contained"
+              type="submit"
+              disabled={loading}
+              startIcon={
+                loading && <CircularProgress size="24px" color="primary" />
+              }
+            >
+              สมัครสมาชิก
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </CardContainer>
+  )
+}
+
+export default EditCastingProfile

--- a/apps/web/src/modules/profile/edit/casting/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.tsx
@@ -2,7 +2,6 @@ import { Button, CircularProgress, Grid } from '@mui/material'
 import FormController from 'common/components/FormController'
 import ProfileImage from 'common/components/ProfileImage'
 import { Fragment } from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { FORM_LAYOUT } from './constants'
 import useEditCastingForm from './hooks/useEditCastingForm'
@@ -34,7 +33,7 @@ const EditCastingProfile = () => {
               )}
               <FormController
                 // I do not know why I cannot directly pass control
-                control={control as unknown as Control<FieldValues>}
+                control={control as any}
                 handleUploadFile={handleUploadImage}
                 {...props}
               />

--- a/apps/web/src/modules/profile/edit/casting/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.tsx
@@ -59,7 +59,7 @@ const EditCastingProfile = () => {
                   loading && <CircularProgress size="24px" color="primary" />
                 }
               >
-                สมัครสมาชิก
+                บันทึกข้อมูล
               </Button>
             </Grid>
           </Grid>

--- a/apps/web/src/modules/profile/edit/casting/index.tsx
+++ b/apps/web/src/modules/profile/edit/casting/index.tsx
@@ -8,53 +8,63 @@ import useEditCastingForm from './hooks/useEditCastingForm'
 import { CardContainer } from './styled'
 
 const EditCastingProfile = () => {
-  const { handleClickSubmit, control, imageUrl, handleUploadImage, loading } =
-    useEditCastingForm()
+  const {
+    handleClickSubmit,
+    control,
+    imageUrl,
+    isDataLoading,
+    handleUploadImage,
+    loading,
+  } = useEditCastingForm()
 
   return (
     <CardContainer variant="outlined">
-      <form onSubmit={handleClickSubmit}>
-        <Grid container spacing={2} sx={{ padding: '12px' }}>
-          {FORM_LAYOUT.map((props) => (
-            <Fragment key={JSON.stringify(props)}>
-              {props.type === 'uploadFile' && (
-                <Grid item width="100%">
-                  <ProfileImage
-                    src={imageUrl}
-                    userId={123}
-                    firstName="hello"
-                    sx={{
-                      margin: 'auto',
-                      width: '150px',
-                      height: '150px',
-                    }}
-                  />
-                </Grid>
-              )}
-              <FormController
-                // I do not know why I cannot directly pass control
-                control={control as any}
-                handleUploadFile={handleUploadImage}
-                {...props}
-              />
-            </Fragment>
-          ))}
-          <Grid item width="100%" display="flex" justifyContent="center">
-            <Button
-              sx={{ borderRadius: '12px' }}
-              size="large"
-              variant="contained"
-              type="submit"
-              disabled={loading}
-              startIcon={
-                loading && <CircularProgress size="24px" color="primary" />
-              }
-            >
-              สมัครสมาชิก
-            </Button>
+      {isDataLoading ? (
+        <CircularProgress />
+      ) : (
+        <form onSubmit={handleClickSubmit}>
+          <Grid container spacing={2} sx={{ padding: '12px' }}>
+            {FORM_LAYOUT.map((props) => (
+              <Fragment key={JSON.stringify(props)}>
+                {props.type === 'uploadFile' && (
+                  <Grid item width="100%">
+                    <ProfileImage
+                      src={imageUrl}
+                      userId={123}
+                      firstName="hello"
+                      sx={{
+                        margin: 'auto',
+                        width: '150px',
+                        height: '150px',
+                      }}
+                    />
+                  </Grid>
+                )}
+                <FormController
+                  // I do not know why I cannot directly pass control
+                  control={control as any}
+                  handleUploadFile={handleUploadImage}
+                  {...props}
+                />
+              </Fragment>
+            ))}
+            <Grid item width="100%" display="flex" justifyContent="center">
+              <Button
+                sx={{ borderRadius: '12px' }}
+                size="large"
+                variant="contained"
+                type="submit"
+                disabled={loading}
+                startIcon={
+                  loading && <CircularProgress size="24px" color="primary" />
+                }
+              >
+                สมัครสมาชิก
+              </Button>
+            </Grid>
           </Grid>
-        </Grid>
-      </form>
+        </form>
+      )}
     </CardContainer>
   )
 }

--- a/apps/web/src/modules/profile/edit/casting/styled.ts
+++ b/apps/web/src/modules/profile/edit/casting/styled.ts
@@ -1,0 +1,10 @@
+import { Card, styled } from '@mui/material'
+
+export const CardContainer = styled(Card)`
+  height: fit-content;
+  margin: 20px;
+  padding: 16px;
+  width: 100%;
+  max-width: 500px;
+  border-radius: 10px;
+`

--- a/apps/web/src/modules/profile/edit/casting/styled.ts
+++ b/apps/web/src/modules/profile/edit/casting/styled.ts
@@ -1,10 +1,13 @@
 import { Card, styled } from '@mui/material'
 
 export const CardContainer = styled(Card)`
+  display: flex;
+  justify-content: center;
   height: fit-content;
   margin: 20px;
   padding: 16px;
   width: 100%;
   max-width: 500px;
+  min-height: 300px;
   border-radius: 10px;
 `

--- a/apps/web/src/modules/profile/edit/pages/index.tsx
+++ b/apps/web/src/modules/profile/edit/pages/index.tsx
@@ -1,0 +1,16 @@
+import { UserType } from '@modela/dtos'
+import { useUser } from 'common/context/UserContext'
+import withGuard from 'common/hoc/withGuard'
+
+import EditCastingProfile from '../casting'
+
+const EditProfilePage = () => {
+  const { user } = useUser()
+  if (user?.type === UserType.CASTING) return <EditCastingProfile />
+  return <>Actor Edit Page</>
+}
+
+export default withGuard(EditProfilePage, 'verified', [
+  UserType.ACTOR,
+  UserType.CASTING,
+])

--- a/apps/web/src/modules/rejected/actor/constants.ts
+++ b/apps/web/src/modules/rejected/actor/constants.ts
@@ -19,12 +19,9 @@ const GENDER_CHOICE: MenuItemProps[] = [
   },
 ]
 
-export const FORM_LAYOUT: Omit<
-  IFormControllerProps<IEditActorInfoSchema>,
-  'control'
->[] = [
+export const FORM_LAYOUT: IFormControllerProps<IEditActorInfoSchema>[] = [
   {
-    type: 'typography',
+    type: 'title',
     label: 'แก้ไขข้อมูลนักแสดง',
   },
   {

--- a/apps/web/src/modules/rejected/actor/index.tsx
+++ b/apps/web/src/modules/rejected/actor/index.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, CircularProgress, Grid } from '@mui/material'
 import FormController from 'common/components/FormController'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { FORM_LAYOUT } from './constants'
 import useActorForm from './hooks/useActorForm'
@@ -16,7 +15,7 @@ const EditActorInfoForm = ({ initialData }: EditActorInfoFormProps) => {
       <Grid container spacing={2} sx={{ padding: '12px' }}>
         {FORM_LAYOUT.map((props) => (
           <FormController
-            control={control as unknown as Control<FieldValues>}
+            control={control as any}
             key={JSON.stringify(props)}
             handleUploadFile={
               props.type === 'uploadFile' ? handleUploadFile : undefined

--- a/apps/web/src/modules/signup/actor/constants.ts
+++ b/apps/web/src/modules/signup/actor/constants.ts
@@ -19,10 +19,7 @@ const GENDER_CHOICE: MenuItemProps[] = [
   },
 ]
 
-export const FORM_LAYOUT: Omit<
-  IFormControllerProps<IActorSignupSchemaType>,
-  'control'
->[] = [
+export const FORM_LAYOUT: IFormControllerProps<IActorSignupSchemaType>[] = [
   {
     type: 'divider',
   },

--- a/apps/web/src/modules/signup/actor/index.tsx
+++ b/apps/web/src/modules/signup/actor/index.tsx
@@ -2,7 +2,6 @@ import { Box, Button, CircularProgress, Grid, Typography } from '@mui/material'
 import FormController from 'common/components/FormController'
 import withGuard from 'common/hoc/withGuard'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { FORM_LAYOUT } from './constants'
 import useActorForm from './hooks/useActorForm'
@@ -27,7 +26,7 @@ const ActorSignUp = () => {
           {FORM_LAYOUT.map((props) => (
             <FormController
               // I do not know why I cannot directly pass control
-              control={control as unknown as Control<FieldValues>}
+              control={control as any}
               key={JSON.stringify(props)}
               handleUploadFile={
                 props.type === 'uploadFile' ? handleUploadFile : undefined

--- a/apps/web/src/modules/signup/casting/constants.ts
+++ b/apps/web/src/modules/signup/casting/constants.ts
@@ -2,10 +2,7 @@ import { IFormControllerProps } from 'common/components/FormController/types'
 
 import { ICastingSignupSchemaType } from './hooks/useCastingForm/schema'
 
-export const FORM_LAYOUT: Omit<
-  IFormControllerProps<ICastingSignupSchemaType>,
-  'control'
->[] = [
+export const FORM_LAYOUT: IFormControllerProps<ICastingSignupSchemaType>[] = [
   {
     type: 'divider',
   },

--- a/apps/web/src/modules/signup/casting/index.tsx
+++ b/apps/web/src/modules/signup/casting/index.tsx
@@ -2,7 +2,6 @@ import { Box, Button, CircularProgress, Grid, Typography } from '@mui/material'
 import FormController from 'common/components/FormController'
 import withGuard from 'common/hoc/withGuard'
 import React from 'react'
-import { Control, FieldValues } from 'react-hook-form'
 
 import { FORM_LAYOUT } from './constants'
 import useCastingForm from './hooks/useCastingForm'
@@ -27,7 +26,7 @@ const CastingSignup = () => {
           {FORM_LAYOUT.map((props) => (
             <FormController
               // I do not know why I cannot directly pass control
-              control={control as unknown as Control<FieldValues>}
+              control={control as any}
               key={JSON.stringify(props)}
               handleUploadFile={
                 props.type === 'uploadFile' ? handleUploadFile : undefined

--- a/apps/web/src/pages/profile/edit.ts
+++ b/apps/web/src/pages/profile/edit.ts
@@ -1,1 +1,1 @@
-export { default } from 'modules/profile/edit/casting'
+export { default } from 'modules/profile/edit/pages/'

--- a/apps/web/src/pages/profile/edit.ts
+++ b/apps/web/src/pages/profile/edit.ts
@@ -1,0 +1,1 @@
+export { default } from 'modules/profile/edit/casting'


### PR DESCRIPTION
## What did you do

<!--## For frontend please also paste the image of the part that you worked on-->

- Implement profile edit for casting page
- Refactor FormController to be more type strict

## Demo

<!--## Link to the page / API that you did in dev environment-->

![image](https://user-images.githubusercontent.com/35169079/220349144-b5d559be-fa11-4483-aaa1-1514c03bd71c.png)

- Login as one of `Casting` account
- https://dev.modela.miello.dev/profile/edit

## Limitation
- This PR does not implement Upload image yet
