### PR TITLE
[114] Implement actor create resumes API @POST

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { ExampleModule } from 'src/modules/example/example.module'
 import { ApplicationModule } from 'src/modules/job/application/application.module'
 import { JobModule } from 'src/modules/job/job.module'
 import { ReportModule } from 'src/modules/report/report.module'
+import { ResumeModule } from 'src/modules/resume/resume.module'
 import { UserModule } from 'src/modules/user/user.module'
 
 import { configuration } from '../config/configuration'
@@ -23,6 +24,7 @@ import { AppService } from './app.service'
     UserModule,
     ReportModule,
     ApplicationModule,
+    ResumeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -1,8 +1,9 @@
 import { UserType } from '@modela/database'
-import { JwtDto, PostResumeDto } from '@modela/dtos'
+import { JwtDto, PostResumeDto, ResumeIdDto } from '@modela/dtos'
 import { Body, Controller, Post } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiOperation,
   ApiTags,
@@ -20,6 +21,7 @@ export class ResumeController {
 
   @Post()
   @UseAuthGuard(UserType.ACTOR)
+  @ApiCreatedResponse({ type: ResumeIdDto })
   @ApiUnauthorizedResponse({ description: 'User is not logged in' })
   @ApiForbiddenResponse({ description: 'User is not an actor' })
   @ApiBadRequestResponse({ description: 'Wrong format' })

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -13,8 +13,8 @@ import { UseAuthGuard } from '../auth/misc/jwt.decorator'
 import { User } from '../auth/misc/user.decorator'
 import { ResumeService } from './resume.service'
 
-@ApiTags('resume')
-@Controller('resume')
+@ApiTags('resumes')
+@Controller('resumes')
 export class ResumeController {
   constructor(private readonly resumeService: ResumeService) {}
 

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -1,6 +1,29 @@
-import { Controller } from '@nestjs/common'
-import { ApiTags } from '@nestjs/swagger'
+import { UserType } from '@modela/database'
+import { JwtDto, PostResumeDto } from '@modela/dtos'
+import { Body, Controller, Post } from '@nestjs/common'
+import {
+  ApiBadRequestResponse,
+  ApiForbiddenResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+
+import { UseAuthGuard } from '../auth/misc/jwt.decorator'
+import { User } from '../auth/misc/user.decorator'
 
 @ApiTags('resume')
 @Controller('resume')
-export class ResumeController {}
+export class ResumeController {
+  @Post()
+  @UseAuthGuard()
+  @UseAuthGuard(UserType.ACTOR)
+  @ApiUnauthorizedResponse({ description: 'User is not logged in' })
+  @ApiForbiddenResponse({ description: 'User is not an actor' })
+  @ApiBadRequestResponse({ description: 'Wrong format' })
+  @ApiOperation({ summary: 'adds resume to user profile' })
+  createJob(@Body() postResumeDto: PostResumeDto, @User() user: JwtDto) {
+    // placeholder so eslint doesn't complain
+    return postResumeDto.name + user.userId
+  }
+}

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -1,0 +1,6 @@
+import { Controller } from '@nestjs/common'
+import { ApiTags } from '@nestjs/swagger'
+
+@ApiTags('resume')
+@Controller('resume')
+export class ResumeController {}

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -19,7 +19,6 @@ export class ResumeController {
   constructor(private readonly resumeService: ResumeService) {}
 
   @Post()
-  @UseAuthGuard()
   @UseAuthGuard(UserType.ACTOR)
   @ApiUnauthorizedResponse({ description: 'User is not logged in' })
   @ApiForbiddenResponse({ description: 'User is not an actor' })

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -11,10 +11,13 @@ import {
 
 import { UseAuthGuard } from '../auth/misc/jwt.decorator'
 import { User } from '../auth/misc/user.decorator'
+import { ResumeService } from './resume.service'
 
 @ApiTags('resume')
 @Controller('resume')
 export class ResumeController {
+  constructor(private readonly resumeService: ResumeService) {}
+
   @Post()
   @UseAuthGuard()
   @UseAuthGuard(UserType.ACTOR)
@@ -23,7 +26,6 @@ export class ResumeController {
   @ApiBadRequestResponse({ description: 'Wrong format' })
   @ApiOperation({ summary: 'adds resume to user profile' })
   createJob(@Body() postResumeDto: PostResumeDto, @User() user: JwtDto) {
-    // placeholder so eslint doesn't complain
-    return postResumeDto.name + user.userId
+    return this.resumeService.createResume(postResumeDto, user)
   }
 }

--- a/apps/api/src/modules/resume/resume.module.ts
+++ b/apps/api/src/modules/resume/resume.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common'
+import { PrismaModule } from 'src/database/prisma.module'
+
+import { ResumeController } from './resume.controller'
+import { ResumeRepository } from './resume.respository'
+import { ResumeService } from './resume.service'
 
 @Module({
-  imports: [],
-  controllers: [],
-  providers: [],
+  imports: [PrismaModule],
+  controllers: [ResumeController],
+  providers: [ResumeService, ResumeRepository],
   exports: [],
 })
 export class ResumeModule {}

--- a/apps/api/src/modules/resume/resume.module.ts
+++ b/apps/api/src/modules/resume/resume.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [],
+  exports: [],
+})
+export class ResumeModule {}

--- a/apps/api/src/modules/resume/resume.respository.ts
+++ b/apps/api/src/modules/resume/resume.respository.ts
@@ -1,7 +1,29 @@
-import { Injectable } from '@nestjs/common'
+import { JwtDto, PostResumeDto } from '@modela/dtos'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
 @Injectable()
-export class JobRepository {
+export class ResumeRepository {
   constructor(private prisma: PrismaService) {}
+
+  async createResume(postResumeDto: PostResumeDto, user: JwtDto) {
+    const actor = await this.prisma.actor.findUnique({
+      where: { actorId: user.userId },
+    })
+    if (!actor) {
+      throw new NotFoundException('Actor not found')
+    }
+    const resume = await this.prisma.resume.create({
+      data: {
+        ...postResumeDto,
+        Actor: {
+          connect: {
+            actorId: user.userId,
+          },
+        },
+      },
+    })
+
+    return { resumeId: resume.resumeId }
+  }
 }

--- a/apps/api/src/modules/resume/resume.respository.ts
+++ b/apps/api/src/modules/resume/resume.respository.ts
@@ -1,24 +1,30 @@
+import { Actor } from '@modela/database'
 import { JwtDto, PostResumeDto } from '@modela/dtos'
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
 @Injectable()
 export class ResumeRepository {
   constructor(private prisma: PrismaService) {}
 
-  async createResume(postResumeDto: PostResumeDto, user: JwtDto) {
+  async getActorFromUser(user: JwtDto) {
     const actor = await this.prisma.actor.findUnique({
       where: { actorId: user.userId },
     })
-    if (!actor) {
-      throw new NotFoundException('Actor not found')
-    }
+    return actor
+  }
+
+  async createResume(
+    postResumeDto: PostResumeDto,
+    actor: Actor,
+    userId: number,
+  ) {
     const resume = await this.prisma.resume.create({
       data: {
         ...postResumeDto,
         Actor: {
           connect: {
-            actorId: user.userId,
+            actorId: userId,
           },
         },
       },

--- a/apps/api/src/modules/resume/resume.respository.ts
+++ b/apps/api/src/modules/resume/resume.respository.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from 'src/database/prisma.service'
+
+@Injectable()
+export class JobRepository {
+  constructor(private prisma: PrismaService) {}
+}

--- a/apps/api/src/modules/resume/resume.service.spec.ts
+++ b/apps/api/src/modules/resume/resume.service.spec.ts
@@ -1,8 +1,48 @@
-/*import { ResumeService } from "./resume.service";
+import { UserStatus, UserType } from '@modela/database'
+import { Test, TestingModule } from '@nestjs/testing'
+import { PrismaService } from 'src/database/prisma.service'
 
+import { ResumeRepository } from './resume.respository'
+import { ResumeService } from './resume.service'
 
 describe('ResumeService', () => {
-    let service: ResumeService;
-})*/
+  let service: ResumeService
+  let repository: ResumeRepository
 
-export class ResumeTestUnit {}
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ResumeService, ResumeRepository, PrismaService],
+    }).compile()
+
+    service = module.get<ResumeService>(ResumeService)
+    repository = module.get<ResumeRepository>(ResumeRepository)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+    expect(repository).toBeDefined()
+  })
+
+  describe('postResume', () => {
+    const MOCK_RESUME_NAME = 'Test Resume'
+    const MOCK_RESUME_URL = 'github.com'
+
+    const MOCK_ACTOR = {
+      userId: 1,
+      status: UserStatus.ACCEPTED,
+      type: UserType.ACTOR,
+    }
+
+    const postResumeDto = {
+      name: MOCK_RESUME_NAME,
+      resumeUrl: MOCK_RESUME_URL,
+    }
+
+    it('should post resume correctly', async () => {
+      jest.spyOn(repository, 'createResume').mockResolvedValue({ resumeId: 11 })
+      const result = await service.createResume(postResumeDto, MOCK_ACTOR)
+      expect(repository.createResume).toBeCalledWith(postResumeDto, MOCK_ACTOR)
+      expect(result).toEqual({ resumeId: 11 })
+    })
+  })
+})

--- a/apps/api/src/modules/resume/resume.service.spec.ts
+++ b/apps/api/src/modules/resume/resume.service.spec.ts
@@ -1,0 +1,8 @@
+/*import { ResumeService } from "./resume.service";
+
+
+describe('ResumeService', () => {
+    let service: ResumeService;
+})*/
+
+export class ResumeTestUnit {}

--- a/apps/api/src/modules/resume/resume.service.spec.ts
+++ b/apps/api/src/modules/resume/resume.service.spec.ts
@@ -1,4 +1,4 @@
-import { UserStatus, UserType } from '@modela/database'
+import { mock, UserStatus, UserType } from '@modela/database'
 import { Test, TestingModule } from '@nestjs/testing'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -39,9 +39,17 @@ describe('ResumeService', () => {
     }
 
     it('should post resume correctly', async () => {
+      const MOCK_DB_ACTOR = mock('actor').get()
       jest.spyOn(repository, 'createResume').mockResolvedValue({ resumeId: 11 })
+      jest
+        .spyOn(repository, 'getActorFromUser')
+        .mockResolvedValue(MOCK_DB_ACTOR)
       const result = await service.createResume(postResumeDto, MOCK_ACTOR)
-      expect(repository.createResume).toBeCalledWith(postResumeDto, MOCK_ACTOR)
+      expect(repository.createResume).toBeCalledWith(
+        postResumeDto,
+        MOCK_DB_ACTOR,
+        MOCK_ACTOR.userId,
+      )
       expect(result).toEqual({ resumeId: 11 })
     })
   })

--- a/apps/api/src/modules/resume/resume.service.ts
+++ b/apps/api/src/modules/resume/resume.service.ts
@@ -7,12 +7,7 @@ import { ResumeRepository } from './resume.respository'
 export class ResumeService {
   constructor(private readonly repository: ResumeRepository) {}
 
-  private validateResumeDto() {
-    return true
-  }
-
   async createResume(postResumeDto: PostResumeDto, user: JwtDto) {
-    this.validateResumeDto()
     return this.repository.createResume(postResumeDto, user)
   }
 }

--- a/apps/api/src/modules/resume/resume.service.ts
+++ b/apps/api/src/modules/resume/resume.service.ts
@@ -1,5 +1,5 @@
 import { JwtDto, PostResumeDto } from '@modela/dtos'
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 
 import { ResumeRepository } from './resume.respository'
 
@@ -8,6 +8,10 @@ export class ResumeService {
   constructor(private readonly repository: ResumeRepository) {}
 
   async createResume(postResumeDto: PostResumeDto, user: JwtDto) {
-    return this.repository.createResume(postResumeDto, user)
+    const actor = await this.repository.getActorFromUser(user)
+    if (!actor) {
+      throw new NotFoundException('Actor not found')
+    }
+    return this.repository.createResume(postResumeDto, actor, user.userId)
   }
 }

--- a/apps/api/src/modules/resume/resume.service.ts
+++ b/apps/api/src/modules/resume/resume.service.ts
@@ -1,4 +1,18 @@
+import { JwtDto, PostResumeDto } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 
+import { ResumeRepository } from './resume.respository'
+
 @Injectable()
-export class ResumeService {}
+export class ResumeService {
+  constructor(private readonly repository: ResumeRepository) {}
+
+  private validateResumeDto() {
+    return true
+  }
+
+  async createResume(postResumeDto: PostResumeDto, user: JwtDto) {
+    this.validateResumeDto()
+    return this.repository.createResume(postResumeDto, user)
+  }
+}

--- a/apps/api/src/modules/resume/resume.service.ts
+++ b/apps/api/src/modules/resume/resume.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class ResumeService {}

--- a/packages/dtos/index.ts
+++ b/packages/dtos/index.ts
@@ -7,6 +7,7 @@ export * from './src/report'
 export * from './src/user'
 export * from './src/application'
 export * from './src/profile'
+export * from './src/resume'
 
 export {
   UserType,

--- a/packages/dtos/src/resume.ts
+++ b/packages/dtos/src/resume.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger'
+import {
+  IsNotEmpty,
+  IsString,
+  IsUrl,
+} from 'class-validator'
+const maxInt32 = 2147483647 //max int32
+
+export class PostResumeDto{
+
+    @IsString()
+    @IsNotEmpty()
+    @ApiProperty()
+    name: string
+
+    @IsString()
+    @IsNotEmpty()
+    @IsUrl()
+    @ApiProperty()
+    resumeUrl: string
+
+}

--- a/packages/dtos/src/resume.ts
+++ b/packages/dtos/src/resume.ts
@@ -1,12 +1,18 @@
 import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger'
 import {
+  IsInt,
   IsNotEmpty,
   IsString,
   IsUrl,
 } from 'class-validator'
 const maxInt32 = 2147483647 //max int32
 
-export class PostResumeDto{
+export class ResumeDto{
+
+    @IsInt()
+    @IsNotEmpty()
+    @ApiProperty()
+    resumeId: number
 
     @IsString()
     @IsNotEmpty()
@@ -19,4 +25,13 @@ export class PostResumeDto{
     @ApiProperty()
     resumeUrl: string
 
+}
+
+export class PostResumeDto extends OmitType(ResumeDto, ['resumeId']) {}
+
+export class GetResumeDto extends ResumeDto {}
+
+export class GetResumesDto {
+    @ApiProperty({ type: ResumeDto, isArray: true })
+    resumes: ResumeDto[]
 }

--- a/packages/dtos/src/resume.ts
+++ b/packages/dtos/src/resume.ts
@@ -35,3 +35,10 @@ export class GetResumesDto {
     @ApiProperty({ type: ResumeDto, isArray: true })
     resumes: ResumeDto[]
 }
+
+export class ResumeIdDto {
+    @IsInt()
+    @IsNotEmpty()
+    @ApiProperty()
+    resumeId: number
+}


### PR DESCRIPTION
## What did you do

- Implemented POST resume API

## Demo

```
{
  "name": "test resume v1",
  "resumeUrl": "google.com"
}
```
The above should work provided that you are properly logged into a verified actor account.
I suggest slightly modifying to make a v2 and trying again to see if it properly appends.
```
{
  "name": "test resume v3",
  "resumeUrl": "thisisnotaurl"
}
```
The above should raise a bad request exception due to the url being invalid.