### PR TITLE
[71] Implement get jobs for admin API @GET

### DIFF
--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -7,6 +7,7 @@ import {
   JobIdDto,
   JobSummaryDto,
   JwtDto,
+  SearchJobByAdminDto,
   SearchJobDto,
   UserType,
 } from '@modela/dtos'
@@ -49,8 +50,11 @@ export class JobController {
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiForbiddenResponse({ description: 'User is not admin' })
   @ApiBadRequestResponse({ description: 'Wrong format' })
-  findAllByAdmin(@Query() searchJobDto: SearchJobDto, @User() user: JwtDto) {
-    return this.jobService.findAllByAdmin(searchJobDto, user)
+  findAllByAdmin(
+    @Query() searchJobByAdminDto: SearchJobByAdminDto,
+    @User() user: JwtDto,
+  ) {
+    return this.jobService.findAllByAdmin(searchJobByAdminDto, user)
   }
 
   @Get(':id')

--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -1,6 +1,7 @@
 import {
   CreateJobDto,
   EditJobDto,
+  GetJobCardByAdminWithMaxPageDto,
   GetJobCardWithMaxPageDto,
   GetJobDto,
   JobIdDto,
@@ -39,6 +40,17 @@ export class JobController {
   @ApiBadRequestResponse({ description: 'Wrong format' })
   findAll(@Query() searchJobDto: SearchJobDto, @User() user: JwtDto) {
     return this.jobService.findAll(searchJobDto, user)
+  }
+
+  @Get('admin')
+  @UseAuthGuard(UserType.ADMIN)
+  @ApiOperation({ summary: 'get all jobs with filter by admin' })
+  @ApiOkResponse({ type: GetJobCardByAdminWithMaxPageDto, isArray: true })
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiForbiddenResponse({ description: 'User is not admin' })
+  @ApiBadRequestResponse({ description: 'Wrong format' })
+  findAllByAdmin(@Query() searchJobDto: SearchJobDto, @User() user: JwtDto) {
+    return this.jobService.findAllByAdmin(searchJobDto, user)
   }
 
   @Get(':id')

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -2,6 +2,7 @@ import { ApplicationStatus, Job, JobStatus, Prisma } from '@modela/database'
 import {
   CreateJobDto,
   EditJobDto,
+  GetJobCardByAdminDto,
   GetJobCardDto,
   GetJobDto,
   JobSummaryDto,
@@ -94,6 +95,50 @@ export class JobRepository {
       jobCastingImageUrl: job.Casting.User.profileImageUrl,
       castingId: job.castingId,
       castingName: job.Casting.User.firstName,
+    }))
+    return selectedFields
+  }
+
+  async getJobJoinedByAdmin(params: {
+    skip?: number
+    take?: number
+    cursor?: Prisma.JobWhereUniqueInput
+    where?: Prisma.JobWhereInput
+    orderBy?: Prisma.JobOrderByWithRelationInput
+  }): Promise<GetJobCardByAdminDto[]> {
+    //generate join casting and user table params
+    const paramsWithInclude = {
+      ...params,
+      orderBy: {
+        jobId: Prisma.SortOrder.desc,
+      },
+      include: {
+        Casting: {
+          include: {
+            User: true,
+          },
+        },
+        Shooting: true,
+        Report: true,
+      },
+    }
+    //get data
+    const jobs = await this.prisma.job.findMany(paramsWithInclude)
+    //select fields of GetJobDto
+    const selectedFields = jobs.map((job) => ({
+      jobId: job.jobId,
+      title: job.title,
+      companyName: job.Casting.companyName,
+      description: job.description,
+      status: job.status,
+      actorCount: job.actorCount,
+      gender: job.gender,
+      wage: job.wage,
+      applicationDeadline: job.applicationDeadline,
+      jobCastingImageUrl: job.Casting.User.profileImageUrl,
+      castingId: job.castingId,
+      castingName: job.Casting.User.firstName,
+      isReported: job.Report.length > 0,
     }))
     return selectedFields
   }

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -147,7 +147,7 @@ export class JobService {
       params.where.Report = {
         some: {
           createdAt: {
-            gte: new Date('1970-01-01T00:00:00Z'),
+            gte: new Date('0001-01-01T00:00:00Z'),
           },
         },
       }
@@ -157,7 +157,6 @@ export class JobService {
       searchJobDto.status.includes(SearchJobStatus.REPORTED)
     ) {
       params.where.status = undefined
-      console.log('only reported')
     } else {
       params.where.status = {
         in: statusQuery,
@@ -272,13 +271,6 @@ export class JobService {
     //set Default value for limit and page
     searchJobDto.limit = searchJobDto.limit || 20
     searchJobDto.page = searchJobDto.page || 1
-
-    //check if castingId is not equal to user.userId
-    if (user.type == UserType.CASTING) {
-      if (searchJobDto.castingId == undefined)
-        searchJobDto.castingId = user.userId
-      if (searchJobDto.castingId != user.userId) throw new ForbiddenException()
-    }
 
     //set params for getJob
     const params = this.convertRequestToParams(searchJobDto, user)

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -80,6 +80,13 @@ export class JobService {
     const defaultMinWageGte = 0
     const defaultMaxWageLte = maxInt32
 
+    const defaultLimit = 20
+    const defaultPage = 1
+
+    //set Default value for limit and page
+    searchJobDto.limit = searchJobDto.limit || defaultLimit
+    searchJobDto.page = searchJobDto.page || defaultPage
+
     const params = {
       //take and skip from limit and page
       take: Number(searchJobDto.limit),
@@ -240,10 +247,6 @@ export class JobService {
   }
 
   async findAll(searchJobDto: SearchJobDto, user: JwtDto) {
-    //set Default value for limit and page
-    searchJobDto.limit = searchJobDto.limit || 20
-    searchJobDto.page = searchJobDto.page || 1
-
     //check if castingId is not equal to user.userId
     if (user.type == UserType.CASTING) {
       if (searchJobDto.castingId == undefined)
@@ -270,10 +273,6 @@ export class JobService {
   }
 
   async findAllByAdmin(searchJobDto: SearchJobDto, user: JwtDto) {
-    //set Default value for limit and page
-    searchJobDto.limit = searchJobDto.limit || 20
-    searchJobDto.page = searchJobDto.page || 1
-
     //set params for getJob
     const params = this.convertRequestToParams(searchJobDto, user)
 

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -73,7 +73,7 @@ export class JobService {
     const statusQuery = []
 
     //check searchJobByAnyDto is SearchJobByAdminDto or SearchJobDto
-    if (endpoint == '/jobs/admin') {
+    if (endpoint === '/jobs/admin') {
       const searchJobByAdminDto = searchJobByAnyDto as SearchJobByAdminDto
       //make OPEN for default
       searchJobByAdminDto.status = searchJobByAdminDto.status || [
@@ -85,7 +85,7 @@ export class JobService {
 
       // Edge case: if only status is reported, return all status except cancelled
       if (
-        searchJobByAdminDto.status.length == 1 &&
+        searchJobByAdminDto.status.length === 1 &&
         searchJobByAdminDto.status.includes(SearchJobByAdminStatus.REPORTED)
       ) {
         searchJobByAdminDto.status = [
@@ -114,7 +114,7 @@ export class JobService {
         statusQuery.push(JobStatus.CANCELLED)
       }
     }
-    if (endpoint == '/jobs') {
+    if (endpoint === '/jobs') {
       const searchJobByUserDto = searchJobByAnyDto as SearchJobDto
       //make OPEN for default
       searchJobByUserDto.status = searchJobByUserDto.status || [
@@ -304,8 +304,8 @@ export class JobService {
 
   async findAll(searchJobDto: SearchJobDto, user: JwtDto) {
     //check if castingId is not equal to user.userId
-    if (user.type == UserType.CASTING) {
-      if (searchJobDto.castingId == undefined)
+    if (user.type === UserType.CASTING) {
+      if (searchJobDto.castingId === undefined)
         searchJobDto.castingId = user.userId
       if (searchJobDto.castingId != user.userId) throw new ForbiddenException()
     }

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -17,7 +17,6 @@ import {
   ForbiddenException,
   InternalServerErrorException,
 } from '@nestjs/common/exceptions'
-import console from 'console'
 
 import { JobRepository } from './job.repository'
 
@@ -90,7 +89,7 @@ export class JobService {
     const params = {
       //take and skip from limit and page
       take: Number(searchJobDto.limit),
-      skip: (searchJobDto.page - 1) * searchJobDto.limit,
+      skip: (Number(searchJobDto.page) - 1) * Number(searchJobDto.limit),
       //filtering
       where: {
         //joined filter

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -143,7 +143,7 @@ export class JobService {
       statusQuery.push(JobStatus.CANCELLED)
     }
     if (searchJobDto.status.includes(SearchJobStatus.REPORTED)) {
-      //filter only reported job (by create after 1970)
+      //filter only reported job (by create after min date)
       params.where.Report = {
         some: {
           createdAt: {

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -126,6 +126,18 @@ export class JobService {
       searchJobDto.status = [searchJobDto.status]
     }
 
+    // Edge case: if only status is reported, return all status except cancelled
+    if (
+      searchJobDto.status.length == 1 &&
+      searchJobDto.status.includes(SearchJobStatus.REPORTED)
+    ) {
+      searchJobDto.status = [
+        SearchJobStatus.OPEN,
+        SearchJobStatus.CLOSE,
+        SearchJobStatus.REPORTED,
+      ]
+    }
+
     if (searchJobDto.status.includes(SearchJobStatus.OPEN)) {
       statusQuery.push(JobStatus.OPEN)
     }
@@ -143,24 +155,14 @@ export class JobService {
       statusQuery.push(JobStatus.CANCELLED)
     }
     if (searchJobDto.status.includes(SearchJobStatus.REPORTED)) {
-      //filter only reported job (by create after min date)
+      //filter only reported job
       params.where.Report = {
-        some: {
-          createdAt: {
-            gte: new Date('0001-01-01T00:00:00Z'),
-          },
-        },
+        some: {},
       }
     }
-    if (
-      searchJobDto.status.length == 1 &&
-      searchJobDto.status.includes(SearchJobStatus.REPORTED)
-    ) {
-      params.where.status = undefined
-    } else {
-      params.where.status = {
-        in: statusQuery,
-      }
+
+    params.where.status = {
+      in: statusQuery,
     }
 
     //handle gender qyery

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -17,6 +17,11 @@ import { Gender, Job, JobStatus, Shooting } from '@modela/database'
 export enum SearchJobStatus {
   'OPEN' = 'OPEN',
   'CLOSE' = 'CLOSE',
+}
+
+export enum SearchJobByAdminStatus {
+  'OPEN' = 'OPEN',
+  'CLOSE' = 'CLOSE',
   'CANCELLED' = 'CANCELLED',
   'REPORTED' = 'REPORTED',
 }
@@ -114,6 +119,13 @@ export class SearchJobDto {
   @IsOptional()
   @ApiPropertyOptional()
   castingId?: number
+}
+
+export class SearchJobByAdminDto extends OmitType(SearchJobDto,['status']) {
+  @IsOptional()
+  @IsEnum(SearchJobByAdminStatus, { each: true })
+  @ApiPropertyOptional({ enum: SearchJobByAdminStatus, isArray: true })
+  status?: SearchJobByAdminStatus[]
 }
 
 export class ShootingDto implements Partial<Shooting> {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -17,8 +17,9 @@ import { Gender, Job, JobStatus, Shooting } from '@modela/database'
 export enum SearchJobStatus {
   'OPEN' = 'OPEN',
   'CLOSE' = 'CLOSE',
+  'CANCELLED' = 'CANCELLED',
+  'REPORTED' = 'REPORTED',
 }
-
 const maxInt32 = 2147483647 //max int32
 export class SearchJobDto {
   @IsOptional()
@@ -227,9 +228,22 @@ export class GetJobCardDto extends OmitType(EditJobDto, [
   status: JobStatus
 }
 
+export class GetJobCardByAdminDto extends GetJobCardDto {
+  @ApiProperty()
+  isReported: Boolean
+}
+
 export class GetJobCardWithMaxPageDto {
   @ApiProperty({ type: GetJobCardDto, isArray: true })
   jobs: GetJobCardDto[]
+
+  @ApiProperty()
+  maxPage: number
+}
+
+export class GetJobCardByAdminWithMaxPageDto {
+  @ApiProperty({ type: GetJobCardByAdminDto, isArray: true })
+  jobs: GetJobCardByAdminDto[]
 
   @ApiProperty()
   maxPage: number


### PR DESCRIPTION
## What did you do
- implement ```GET /jobs/admin``` endpoint for admin to get reported jobs and filtering

## Demo
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any admin)
```
{
  "email": "admin1@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_findAllByAdmin
- try get jobs with ```REPORTED``` status query on along with any others filters
- should see all reported jobs indicated by boolean ```isReported``` field in each jobs

## Limitation
- not have unit test yet