### PR TITLE
[HOT_FIX][96][99][105][108] fix invalid type and data response of  accept and reject user's registration API

### DIFF
--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,4 +1,10 @@
-import { GetUserDto, JwtDto, UpdateUserStatusDto, UserType } from '@modela/dtos'
+import {
+  GetUserDto,
+  JwtDto,
+  PendingUserDto,
+  UpdateUserStatusDto,
+  UserType,
+} from '@modela/dtos'
 import { Body, Controller, Get, Param, Put } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
@@ -33,7 +39,7 @@ export class UserController {
   @Get('pending')
   @UseAuthGuard(UserType.ADMIN)
   @ApiOperation({ summary: 'get all user pending for admin' })
-  @ApiOkResponse({ type: GetUserDto, isArray: true })
+  @ApiOkResponse({ type: PendingUserDto, isArray: true })
   getPendingUser() {
     return this.userService.getPendingUsers()
   }
@@ -41,7 +47,7 @@ export class UserController {
   @Put(':id/verification')
   @UseAuthGuard(UserType.ADMIN)
   @ApiOperation({ summary: 'accept or reject user with id' })
-  @ApiOkResponse({ type: GetUserDto })
+  @ApiOkResponse({ type: PendingUserDto })
   @ApiNotFoundResponse({ description: 'user not found' })
   updateUserStatus(
     @Param('id') id: string,

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -42,7 +42,7 @@ export class UserService {
   async updateUserStatus(
     userId: number,
     updateUserStatusDto: UpdateUserStatusDto,
-  ): Promise<GetUserDto> {
+  ): Promise<PendingUserDto> {
     //check if user exist
     const user = await this.repository.getUserById(userId)
     if (!user) throw new NotFoundException()

--- a/packages/dtos/src/user.ts
+++ b/packages/dtos/src/user.ts
@@ -53,6 +53,10 @@ export class PendingUserDataDto{
   @ApiProperty()
   lastName: string;
 
+  @ApiPropertyOptional()
+  rejectedReason?: string
+
+  // Casting
   @ApiProperty()
   companyName?: string;
 
@@ -62,6 +66,7 @@ export class PendingUserDataDto{
   @ApiProperty()
   employmentCertUrl?: string;
 
+  // Actor
   @ApiProperty()
   idCardImageUrl?: string;
 


### PR DESCRIPTION
## What did you do
- add rejectedReason in case of respond confirmation in ```PUT /users/:id/verification```
- fix return type and data respond of ```GET /users/pending``` and ```PUT /users/:id/verification``` to be ```PendingUserDataDto```

## Demo
- should not see the weird field in the response, like a password.
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login 
- login with
```
{
  "email": "admin1@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/users/UserController_getUserData
- get pending users to inspect all users that have PENDING status
- https://api-dev.modela.miello.dev/swagger#/users/UserController_updateUserStatus
- choose userId to ACCEPTED, or REJECTED with rejectedReason, recheck again in get pending users

- (if not have PENDING users, open a separate session to signup)
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_signupActor
- signup with
  ```
    {
      "email": "actor.number@gmail.com",
      "password": "password",
      "firstName": "firstName",
      "middleName": "middleName",
      "lastName": "lastName",
      "prefix": "mr",
      "nationality": "nationality",
      "ssn": "string",
      "gender": "MALE",
      "phoneNumber": "0987654321",
      "idCardImageUrl": "card.png"
    }
  ```
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_signupCasting
- signup with
  ```
    {
      "email": "casting.number@gmail.com",
      "password": "password",
      "firstName": "firstName",
      "middleName": "middleName",
      "lastName": "lastName",
      "companyId": "0123456789123",
      "companyName": "myCompany",
      "employmentCertUrl": "cert.png"
    }
  ```

## Limitation
- not have unit test yet
