### PR TITLE
[68] Implement get applied jobs API @GET

### DIFF
--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -3,12 +3,14 @@ import {
   EditJobDto,
   EditJobStatusDto,
   GetJobCardByAdminWithMaxPageDto,
+  GetAppliedJobDto,
   GetJobCardWithMaxPageDto,
   GetJobDto,
   JobIdDto,
   JobSummaryDto,
   JwtDto,
   SearchJobByAdminDto,
+  SearchAppliedJobDto,
   SearchJobDto,
   UserType,
 } from '@modela/dtos'
@@ -56,6 +58,20 @@ export class JobController {
     @User() user: JwtDto,
   ) {
     return this.jobService.findAllByAdmin(searchJobByAdminDto, user)
+  }
+
+  @Get('applied')
+  @UseAuthGuard(UserType.ACTOR)
+  @ApiOperation({ summary: 'get all jobs that actor applied' })
+  @ApiOkResponse({ type: GetAppliedJobDto, isArray: true })
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiForbiddenResponse({ description: 'User is not actor' })
+  @ApiBadRequestResponse({ description: 'Wrong format' })
+  findAllApplied(
+    @Query() searchAppliedJobDto: SearchAppliedJobDto,
+    @User() user: JwtDto,
+  ) {
+    return this.jobService.findAllApplied(searchAppliedJobDto, user)
   }
 
   @Get(':id')

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -169,15 +169,10 @@ export class JobRepository {
             User: true,
           },
         },
-        //only get the latest application
         Application: {
           where: {
             actorId: userId,
           },
-          orderBy: {
-            applicationId: Prisma.SortOrder.desc,
-          },
-          take: 1,
         },
       },
       where: {
@@ -200,26 +195,21 @@ export class JobRepository {
           : undefined,
       },
     })
-    const jobsWithApplicationStatus = []
-    for (const job of jobs) {
-      if (applicationStatus.includes(job.Application[0].status)) {
-        jobsWithApplicationStatus.push({
-          jobId: job.jobId,
-          title: job.title,
-          companyName: job.Casting.companyName,
-          description: job.description,
-          status: job.status,
-          actorCount: job.actorCount,
-          gender: job.gender,
-          wage: job.wage,
-          applicationDeadline: job.applicationDeadline,
-          jobCastingImageUrl: job.Casting.User.profileImageUrl,
-          castingId: job.castingId,
-          castingName: job.Casting.User.firstName,
-          ApplicationStatus: job.Application[0].status,
-        })
-      }
-    }
+    const jobsWithApplicationStatus = jobs.map((job) => ({
+      jobId: job.jobId,
+      title: job.title,
+      companyName: job.Casting.companyName,
+      description: job.description,
+      status: job.status,
+      actorCount: job.actorCount,
+      gender: job.gender,
+      wage: job.wage,
+      applicationDeadline: job.applicationDeadline,
+      jobCastingImageUrl: job.Casting.User.profileImageUrl,
+      castingId: job.castingId,
+      castingName: job.Casting.User.firstName,
+      ApplicationStatus: job.Application[0].status,
+    }))
 
     return jobsWithApplicationStatus
   }

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -6,7 +6,6 @@ import {
   GetJobCardDto,
   GetJobDto,
   JobSummaryDto,
-  SearchAppliedJobDto,
 } from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
@@ -155,7 +154,8 @@ export class JobRepository {
   }
 
   async getJobApplied(
-    searchAppliedJobDto: SearchAppliedJobDto,
+    statusQuery: JobStatus[],
+    applicationStatus: ApplicationStatus[],
     userId: number,
   ): Promise<(GetJobCardDto & { ApplicationStatus })[]> {
     const jobs = await this.prisma.job.findMany({
@@ -172,14 +172,20 @@ export class JobRepository {
         Application: true,
       },
       where: {
+        status: {
+          in: statusQuery,
+        },
         Application: {
           some: {
             actorId: userId,
-            //applicationStatus: searchAppliedJobDto.applicationStatus,
+            status: {
+              in: applicationStatus,
+            },
           },
         },
       },
     })
+
     const jobsWithApplicationStatus = jobs.map((job) => ({
       jobId: job.jobId,
       title: job.title,

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -185,24 +185,32 @@ export class JobRepository {
         },
       },
     })
-
-    const jobsWithApplicationStatus = jobs.map((job) => ({
-      jobId: job.jobId,
-      title: job.title,
-      companyName: job.Casting.companyName,
-      description: job.description,
-      status: job.status,
-      actorCount: job.actorCount,
-      gender: job.gender,
-      wage: job.wage,
-      applicationDeadline: job.applicationDeadline,
-      jobCastingImageUrl: job.Casting.User.profileImageUrl,
-      castingId: job.castingId,
-      castingName: job.Casting.User.firstName,
-      ApplicationStatus: job.Application.find(
-        (application) => application.actorId === userId,
-      ).status,
-    }))
+    const jobsWithApplicationStatus = []
+    //check only lastest application status
+    for (const job of jobs) {
+      //check if lastest application status is in applicationStatus
+      if (
+        applicationStatus.includes(
+          job.Application[job.Application.length - 1].status,
+        )
+      ) {
+        jobsWithApplicationStatus.push({
+          jobId: job.jobId,
+          title: job.title,
+          companyName: job.Casting.companyName,
+          description: job.description,
+          status: job.status,
+          actorCount: job.actorCount,
+          gender: job.gender,
+          wage: job.wage,
+          applicationDeadline: job.applicationDeadline,
+          jobCastingImageUrl: job.Casting.User.profileImageUrl,
+          castingId: job.castingId,
+          castingName: job.Casting.User.firstName,
+          ApplicationStatus: job.Application[job.Application.length - 1].status,
+        })
+      }
+    }
     return jobsWithApplicationStatus
   }
 

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -154,6 +154,7 @@ export class JobRepository {
   }
 
   async getJobApplied(
+    titleSearch: string,
     statusQuery: JobStatus[],
     applicationStatus: ApplicationStatus[],
     userId: number,
@@ -188,6 +189,12 @@ export class JobRepository {
             },
           },
         },
+        title: titleSearch
+          ? {
+              contains: titleSearch,
+              mode: 'insensitive',
+            }
+          : undefined,
       },
     })
     const jobsWithApplicationStatus = []

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -178,20 +178,23 @@ export class JobRepository {
         Application: {
           some: {
             actorId: userId,
-            status: {
-              in: applicationStatus,
-            },
           },
         },
       },
     })
+
     const jobsWithApplicationStatus = []
     //check only lastest application status
     for (const job of jobs) {
       //check if lastest application status is in applicationStatus
+      const applicationStatusList = []
+      for (const application of job.Application) {
+        if (application.actorId === userId)
+          applicationStatusList.push(application.status)
+      }
       if (
         applicationStatus.includes(
-          job.Application[job.Application.length - 1].status,
+          applicationStatusList[applicationStatusList.length - 1],
         )
       ) {
         jobsWithApplicationStatus.push({
@@ -207,7 +210,8 @@ export class JobRepository {
           jobCastingImageUrl: job.Casting.User.profileImageUrl,
           castingId: job.castingId,
           castingName: job.Casting.User.firstName,
-          ApplicationStatus: job.Application[job.Application.length - 1].status,
+          ApplicationStatus:
+            applicationStatusList[applicationStatusList.length - 1],
         })
       }
     }

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -171,6 +171,9 @@ export class JobRepository {
         },
         //only get the latest application
         Application: {
+          where: {
+            actorId: userId,
+          },
           orderBy: {
             applicationId: Prisma.SortOrder.desc,
           },

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -9,6 +9,7 @@ import {
   JwtDto,
   SearchJobByAdminDto,
   SearchJobByAdminStatus,
+  SearchAppliedJobDto,
   SearchJobDto,
   SearchJobStatus,
   UserType,
@@ -342,6 +343,9 @@ export class JobService {
     return result
   }
 
+  async findAllApplied(searchAppliedJobDto: SearchAppliedJobDto, user: JwtDto) {
+    return this.repository.getJobApplied(searchAppliedJobDto, user.userId)
+  }
   async findOne(id: number, user: JwtDto) {
     const job = await this.repository.getJobById(id)
 

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -345,14 +345,17 @@ export class JobService {
 
   async findAllApplied(searchAppliedJobDto: SearchAppliedJobDto, user: JwtDto) {
     //assign and set default value
-    const applicationStatus = searchAppliedJobDto.applicationStatus || [
+    let applicationStatus = searchAppliedJobDto.applicationStatus || [
       ApplicationStatus.PENDING,
     ]
-    const statusQuery = searchAppliedJobDto.status || [
+    let statusQuery = searchAppliedJobDto.status || [
       JobStatus.OPEN,
       JobStatus.SELECTING,
       JobStatus.SELECTION_ENDED,
     ]
+    if (!Array.isArray(applicationStatus))
+      applicationStatus = [applicationStatus]
+    if (!Array.isArray(statusQuery)) statusQuery = [statusQuery]
     return await this.repository.getJobApplied(
       statusQuery,
       applicationStatus,

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -357,6 +357,7 @@ export class JobService {
       applicationStatus = [applicationStatus]
     if (!Array.isArray(statusQuery)) statusQuery = [statusQuery]
     return await this.repository.getJobApplied(
+      searchAppliedJobDto.title,
       statusQuery,
       applicationStatus,
       user.userId,

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -1,4 +1,4 @@
-import { JobStatus } from '@modela/database'
+import { ApplicationStatus, JobStatus } from '@modela/database'
 import {
   CreateJobDto,
   EditJobDto,
@@ -7,9 +7,9 @@ import {
   GetJobCardWithMaxPageDto,
   JobSummaryDto,
   JwtDto,
+  SearchAppliedJobDto,
   SearchJobByAdminDto,
   SearchJobByAdminStatus,
-  SearchAppliedJobDto,
   SearchJobDto,
   SearchJobStatus,
   UserType,
@@ -344,7 +344,20 @@ export class JobService {
   }
 
   async findAllApplied(searchAppliedJobDto: SearchAppliedJobDto, user: JwtDto) {
-    return this.repository.getJobApplied(searchAppliedJobDto, user.userId)
+    //assign and set default value
+    const applicationStatus = searchAppliedJobDto.applicationStatus || [
+      ApplicationStatus.PENDING,
+    ]
+    const statusQuery = searchAppliedJobDto.status || [
+      JobStatus.OPEN,
+      JobStatus.SELECTING,
+      JobStatus.SELECTION_ENDED,
+    ]
+    return await this.repository.getJobApplied(
+      statusQuery,
+      applicationStatus,
+      user.userId,
+    )
   }
   async findOne(id: number, user: JwtDto) {
     const job = await this.repository.getJobById(id)

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -216,6 +216,7 @@ export class CreateJobDto implements EditJobType {
 
 export class EditJobDto extends CreateJobDto {}
 export class EditJobStatusDto {
+  @IsEnum(JobStatus)
   @ApiProperty({enum: JobStatus}) 
   status: JobStatus
 }

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -253,6 +253,11 @@ export class GetJobCardByAdminDto extends GetJobCardDto {
 
 export class SearchAppliedJobDto {
   @IsOptional()
+  @IsString()
+  @ApiPropertyOptional()
+  title?: string
+
+  @IsOptional()
   @IsEnum(ApplicationStatus, { each: true })
   @ApiPropertyOptional({ enum: ApplicationStatus, isArray: true })
   applicationStatus?: ApplicationStatus[]

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -12,7 +12,7 @@ import {
   Max,
   Min,
 } from 'class-validator'
-import { Gender, Job, JobStatus, Shooting } from '@modela/database'
+import { ApplicationStatus, Gender, Job, JobStatus, Shooting } from '@modela/database'
 
 export enum SearchJobStatus {
   'OPEN' = 'OPEN',
@@ -247,6 +247,23 @@ export class GetJobCardDto extends OmitType(EditJobDto, [
 export class GetJobCardByAdminDto extends GetJobCardDto {
   @ApiProperty()
   isReported: Boolean
+}
+
+export class SearchAppliedJobDto {
+  @IsOptional()
+  @IsEnum(SearchJobStatus, { each: true })
+  @ApiPropertyOptional({ enum: SearchJobStatus, isArray: true })
+  status?: SearchJobStatus[]
+  
+  @IsOptional()
+  @IsEnum(ApplicationStatus, { each: true })
+  @ApiPropertyOptional({ enum: ApplicationStatus, isArray: true })
+  applicationStatus?: ApplicationStatus[]
+}
+
+export class GetAppliedJobDto extends GetJobCardDto {
+  @ApiProperty()
+  appliedStatus: JobStatus
 }
 
 export class GetJobCardWithMaxPageDto {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -25,6 +25,7 @@ export enum SearchJobByAdminStatus {
   'CANCELLED' = 'CANCELLED',
   'REPORTED' = 'REPORTED',
 }
+  
 const maxInt32 = 2147483647 //max int32
 export class SearchJobDto {
   @IsOptional()
@@ -251,14 +252,14 @@ export class GetJobCardByAdminDto extends GetJobCardDto {
 
 export class SearchAppliedJobDto {
   @IsOptional()
-  @IsEnum(SearchJobStatus, { each: true })
-  @ApiPropertyOptional({ enum: SearchJobStatus, isArray: true })
-  status?: SearchJobStatus[]
-  
-  @IsOptional()
   @IsEnum(ApplicationStatus, { each: true })
   @ApiPropertyOptional({ enum: ApplicationStatus, isArray: true })
   applicationStatus?: ApplicationStatus[]
+
+  @IsOptional()
+  @IsEnum(JobStatus, { each: true })
+  @ApiPropertyOptional({ enum: JobStatus, isArray: true })
+  status?: JobStatus[]
 }
 
 export class GetAppliedJobDto extends GetJobCardDto {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -269,7 +269,7 @@ export class SearchAppliedJobDto {
 }
 
 export class GetAppliedJobDto extends GetJobCardDto {
-  @ApiProperty()
+  @ApiProperty({enum: JobStatus})
   appliedStatus: JobStatus
 }
 


### PR DESCRIPTION
## What did you do
- implement ```GET /jobs/applied``` endpoint for actor to get applied jobs and filtering
- only able to filter title, jobStatus and applicationStatus
- title is sub-string search, insensitive case
- if not send any parameters (according to design)
  - jobStatus will be ['PENDING']
  - applicationStatus will be ['OPEN','SELECTING',''SELECTION_END']
  - title will be undefined (search any title)

## Demo
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any actor)
```
{
  "email": "actor6@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_findAllApplied
- try get jobs with any jobStatus and applicationStatus combination
- should see all jobs and applicationStatus of the actor

## Limitation
- not have unit test yet