### PR TITLE
[77] Implement change job's status API @PUT

### DIFF
--- a/apps/api/src/modules/job/job.controller.ts
+++ b/apps/api/src/modules/job/job.controller.ts
@@ -1,6 +1,7 @@
 import {
   CreateJobDto,
   EditJobDto,
+  EditJobStatusDto,
   GetJobCardByAdminWithMaxPageDto,
   GetJobCardWithMaxPageDto,
   GetJobDto,
@@ -83,6 +84,26 @@ export class JobController {
     @User() user: JwtDto,
   ) {
     return this.jobService.update(+id, updateJobDto, user.userId)
+  }
+
+  @Put(':id/status')
+  @ApiOperation({ summary: 'update status of job by id' })
+  @ApiCreatedResponse({ type: JobIdDto })
+  @UseAuthGuard(UserType.CASTING)
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiForbiddenResponse({ description: 'User is not owner' })
+  @ApiBadRequestResponse({ description: 'Wrong format' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  updateStatus(
+    @Param('id') id: string,
+    @Body() updateJobStatusDto: EditJobStatusDto,
+    @User() user: JwtDto,
+  ) {
+    return this.jobService.updateStatus(
+      +id,
+      updateJobStatusDto.status,
+      user.userId,
+    )
   }
 
   @Post()

--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -45,6 +45,16 @@ export class JobRepository {
     return { jobId: updatedJob.jobId }
   }
 
+  async updateJobStatus(id: number, status: JobStatus) {
+    const updatedJob = await this.prisma.job.update({
+      where: { jobId: id },
+      data: {
+        status,
+      },
+    })
+    return { jobId: updatedJob.jobId }
+  }
+
   async getJobCount(params: {
     skip?: number
     take?: number

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -384,7 +384,7 @@ export class JobService {
     }
     if (job.status === JobStatus.CANCELLED || job.status === JobStatus.FINISHED)
       throw new ForbiddenException(
-        "You can't update status job that is not cancelled or finished.",
+        "You can't update status job that is cancelled or finished.",
       )
     return this.repository.updateJobStatus(id, updateJobStatus)
   }

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -374,6 +374,21 @@ export class JobService {
     return this.repository.updateJob(id, updateJobDto)
   }
 
+  async updateStatus(id: number, updateJobStatus: JobStatus, userId: number) {
+    const job = await this.repository.getBaseJobById(id)
+    if (!job) throw new NotFoundException('Job not found')
+    if (job.castingId !== userId) {
+      throw new ForbiddenException(
+        "You don't have permission to update status of this job",
+      )
+    }
+    if (job.status === JobStatus.CANCELLED || job.status === JobStatus.FINISHED)
+      throw new ForbiddenException(
+        "You can't update status job that is not cancelled or finished.",
+      )
+    return this.repository.updateJobStatus(id, updateJobStatus)
+  }
+
   async getJobSummaryById(
     jobId: number,
     userId: number,

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -215,8 +215,7 @@ export class CreateJobDto implements EditJobType {
 
 export class EditJobDto extends CreateJobDto {}
 export class EditJobStatusDto {
-  @IsEnum(JobStatus)
-  @ApiProperty()
+  @ApiProperty({enum: JobStatus}) 
   status: JobStatus
 }
 

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -214,6 +214,11 @@ export class CreateJobDto implements EditJobType {
 }
 
 export class EditJobDto extends CreateJobDto {}
+export class EditJobStatusDto {
+  @IsEnum(JobStatus)
+  @ApiProperty()
+  status: JobStatus
+}
 
 export class GetJobCardDto extends OmitType(EditJobDto, [
   'role',


### PR DESCRIPTION
## What did you do
- Implement  ```PUT /jobs/:id/status``` endpoint for casting to update job's status
- Limit the jobs that have JobStatus FINISHED, CANCELLED can't update JobStatus

## Demo
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any casting)
```
{
  "email": "casting2@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_findAll
- get all jobs that the casting own (also select OPEN, CLOSE status to view all jobs)
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_updateStatus
- update job's status to OPEN, SELECTING, SELECTION_ENDED, FINISHED, CANCELLED
- repeat get all jobs and update again
- also try with jobs that not own and from other roles

## Limitation
- not have unit test yet

## Concern
- can it update skipped order of status change? (OPEN -> SELECTION_ENDED, SELECTING -> FINISHED )
- can it update reverse order of status change? (CANCELLED -> FINISHED -> SELECTION_ENDED -> SELECTING -> OPEN)
- can admin update JobStatus to CANCELLED? or else?