### PR TITLE
[83] Implement get profile API @GET

### DIFF
--- a/apps/api/src/modules/user/profile/profile.controller.ts
+++ b/apps/api/src/modules/user/profile/profile.controller.ts
@@ -2,12 +2,14 @@ import {
   EditActorProfileDto,
   EditCastingProfileDto,
   GetProfileForEditingDto,
+  GetProfileForViewingDto,
   JwtDto,
   UserType,
 } from '@modela/dtos'
-import { Body, Controller, Get, Put } from '@nestjs/common'
+import { Body, Controller, Get, Param, Put } from '@nestjs/common'
 import {
   ApiForbiddenResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -59,5 +61,18 @@ export class ProfileController {
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   getProfile(@User() user: JwtDto) {
     return this.profileService.getProfileForEditing(+user.userId, user.type)
+  }
+
+  @Get(':id')
+  @UseAuthGuard(UserType.CASTING, UserType.ACTOR)
+  @ApiOperation({
+    summary: `get user's profile `,
+  })
+  @ApiOkResponse({ type: GetProfileForViewingDto })
+  @ApiForbiddenResponse({ description: 'User is not an casting or actor' })
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiNotFoundResponse({ description: 'User not found' })
+  getProfileById(@Param('id') id: number) {
+    return this.profileService.getProfileById(+id)
   }
 }

--- a/apps/api/src/modules/user/profile/profile.service.ts
+++ b/apps/api/src/modules/user/profile/profile.service.ts
@@ -2,9 +2,10 @@ import {
   EditActorProfileDto,
   EditCastingProfileDto,
   GetProfileForEditingDto,
+  GetProfileForViewingDto,
   UserType,
 } from '@modela/dtos'
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 
 import { ProfileRepository } from './profile.repository'
 @Injectable()
@@ -51,5 +52,13 @@ export class ProfileService {
         ...(await this.repository.getActorProfileForEditing(id)),
       },
     }
+  }
+
+  async getProfileById(id: number): Promise<GetProfileForViewingDto> {
+    const user = await this.repository.getUserProfileById(id)
+    if (!user) {
+      throw new NotFoundException()
+    }
+    return user
   }
 }

--- a/packages/dtos/src/profile.ts
+++ b/packages/dtos/src/profile.ts
@@ -1,4 +1,4 @@
-import { Actor, Casting, User, UserType } from '@modela/database'
+import { Actor, Casting, Gender, User, UserType } from '@modela/database'
 import { ApiProperty, refs } from '@nestjs/swagger'
 import {
   IsDateString,
@@ -114,4 +114,93 @@ export class GetProfileForEditingDto {
     oneOf: refs(EditActorProfileDto, EditCastingProfileDto),
   })
   data: EditActorProfileDto | EditCastingProfileDto
+}
+export class GetUserProfileDto implements Partial<User> {
+  @ApiProperty()
+  profileImageUrl?: string
+
+  @ApiProperty()
+  phoneNumber?: string
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  middleName?: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty()
+  description?: string;
+}
+
+export class GetCastingProfileDto extends GetUserProfileDto {
+  @ApiProperty()
+  companyName: string;
+}
+export class GetActorProfileDto extends GetUserProfileDto implements EditActorProfileDto {
+  @ApiProperty()
+  prefix?: string;
+
+  @ApiProperty()
+  nationality?: string;
+
+  @ApiProperty()
+  gender?: Gender;
+
+  @ApiProperty()
+  ethnicity?: string
+  
+  @ApiProperty()
+  age?: number;
+
+  @ApiProperty()
+  religion?: string
+
+  @ApiProperty()
+  nickname?: string
+
+  @ApiProperty()
+  height?: number
+
+  @ApiProperty()
+  weight?: number
+
+  @ApiProperty()
+  eyeColor?: string
+
+  @ApiProperty()
+  hairColor?: string
+
+  @ApiProperty()
+  waist?: number
+
+  @ApiProperty()
+  bust?: number
+
+  @ApiProperty()
+  hips?: number
+
+  // assume that it is EU format
+  @ApiProperty()
+  shoeSize?: number
+
+  @ApiProperty()
+  skinShade?: string
+
+  
+
+
+
+}
+
+export class GetProfileForViewingDto {
+  @ApiProperty({ enum: UserType, example: UserType.ACTOR })
+  type: UserType
+
+  @ApiProperty({
+    oneOf: refs(GetActorProfileDto, GetCastingProfileDto),
+  })
+  data: GetActorProfileDto | GetCastingProfileDto
 }

--- a/packages/dtos/src/profile.ts
+++ b/packages/dtos/src/profile.ts
@@ -146,7 +146,7 @@ export class GetActorProfileDto extends GetUserProfileDto implements EditActorPr
   @ApiProperty()
   nationality?: string;
 
-  @ApiProperty()
+  @ApiProperty({ enum: Gender })
   gender?: Gender;
 
   @ApiProperty()


### PR DESCRIPTION
## What did you do
- implement ```GET /profile/:id``` endpoint for user to get user's profile
- create new related Dto

## Demo
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any actor)
```
{
  "email": "actor6@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/profile/ProfileController_getProfileById
- get any actor's (11-20) or casting (21-30) profile by Id

## Limitation
- not have unit test yet

## Concern
- not sure this Endpoint can be use for casting to view actor's profile only or vice versa or actor view actor or casting view casting
  - according to user's story casting view actor
  - according to draft API's Endpoint both can view