### PR TITLE
[71] fix get jobs for admin API @GET

### DIFF
--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -83,16 +83,12 @@ export class JobService {
         searchJobByAdminDto.status = [searchJobByAdminDto.status]
       }
 
-      // Edge case: if only status is reported, return all status except cancelled
+      // Edge case: if only status is reported, return default JobStatus search (OPEN only)
       if (
         searchJobByAdminDto.status.length === 1 &&
         searchJobByAdminDto.status.includes(SearchJobByAdminStatus.REPORTED)
       ) {
-        searchJobByAdminDto.status = [
-          SearchJobByAdminStatus.OPEN,
-          SearchJobByAdminStatus.CLOSE,
-          SearchJobByAdminStatus.REPORTED,
-        ]
+        searchJobByAdminDto.status = [SearchJobByAdminStatus.OPEN]
       }
 
       if (searchJobByAdminDto.status.includes(SearchJobByAdminStatus.OPEN)) {
@@ -104,9 +100,6 @@ export class JobService {
           JobStatus.SELECTION_ENDED,
           JobStatus.FINISHED,
         )
-        if (user.type === UserType.CASTING) {
-          statusQuery.push(JobStatus.CANCELLED)
-        }
       }
       if (
         searchJobByAdminDto.status.includes(SearchJobByAdminStatus.CANCELLED)


### PR DESCRIPTION
## What did you do
- fix  ```GET /jobs/admin``` endpoint for admin to get reported jobs and filtering
- when only query for reported jobs, will apply the default search of JobStatus (['OPEN'])

## Demo
- should see only OPEN jobs when only query for reported jobs
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any admin)
```
{
  "email": "admin1@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_findAllByAdmin
- try get jobs with ```REPORTED``` status query on along with any others filters
- should see all reported jobs indicated by boolean ```isReported``` field in each jobs

## Limitation
- not have unit test yet