### PR TITLE
[68] fix type in get applied jobs API @GET

### DIFF
--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -2,6 +2,7 @@ import { ApplicationStatus, Job, JobStatus, Prisma } from '@modela/database'
 import {
   CreateJobDto,
   EditJobDto,
+  GetAppliedJobDto,
   GetJobCardByAdminDto,
   GetJobCardDto,
   GetJobDto,
@@ -158,7 +159,7 @@ export class JobRepository {
     statusQuery: JobStatus[],
     applicationStatus: ApplicationStatus[],
     userId: number,
-  ): Promise<(GetJobCardDto & { ApplicationStatus })[]> {
+  ): Promise<GetAppliedJobDto[]> {
     const jobs = await this.prisma.job.findMany({
       orderBy: {
         jobId: Prisma.SortOrder.desc,
@@ -208,7 +209,7 @@ export class JobRepository {
       jobCastingImageUrl: job.Casting.User.profileImageUrl,
       castingId: job.castingId,
       castingName: job.Casting.User.firstName,
-      ApplicationStatus: job.Application[0].status,
+      appliedStatus: job.Application[0].status,
     }))
 
     return jobsWithApplicationStatus

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -269,8 +269,8 @@ export class SearchAppliedJobDto {
 }
 
 export class GetAppliedJobDto extends GetJobCardDto {
-  @ApiProperty({enum: JobStatus})
-  appliedStatus: JobStatus
+  @ApiProperty({enum: ApplicationStatus})
+  appliedStatus: ApplicationStatus
 }
 
 export class GetJobCardWithMaxPageDto {

--- a/packages/dtos/src/job.ts
+++ b/packages/dtos/src/job.ts
@@ -242,7 +242,7 @@ export class GetJobCardDto extends OmitType(EditJobDto, [
   @ApiProperty()
   castingName: string
 
-  @ApiProperty()
+  @ApiProperty({enum: JobStatus})
   status: JobStatus
 }
 
@@ -315,7 +315,7 @@ export class JobIdDto {
 }
 
 export class JobSummaryDto {
-  @ApiProperty()
+  @ApiProperty({enum: JobStatus})
   status: JobStatus
 
   @ApiProperty()


### PR DESCRIPTION
## What did you do
- fix ```GET /jobs/applied``` endpoint for actor to get applied jobs and filtering
- change the type of appliedStatus in GetAppliedJobDto from JobStatus to ApplicationStatus 

## Demo
- should see the correct type and example in swagger like this ("appliedStatus" should be "PENDING")
```
[
  {
    "title": "string",
    "description": "string",
    "gender": "string",
    "actorCount": 0,
    "wage": 0,
    "applicationDeadline": "2023-02-26T13:24:05.450Z",
    "jobId": 0,
    "companyName": "string",
    "jobCastingImageUrl": "string",
    "castingId": 0,
    "castingName": "string",
    "status": "string",
    "appliedStatus": "PENDING"
  }
]
```
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login with (or any actor)
```
{
  "email": "actor6@gmail.com",
  "password": "password"
}
```
- https://api-dev.modela.miello.dev/swagger#/jobs/JobController_findAllApplied
- try get jobs with any jobStatus and applicationStatus combination
- should see all jobs and applicationStatus of the actor

## Limitation
- not have unit test yet