### PR TITLE
[77] add feature in change job's status API @PUT

### DIFF
--- a/apps/api/src/modules/job/job.repository.ts
+++ b/apps/api/src/modules/job/job.repository.ts
@@ -87,7 +87,7 @@ export class JobRepository {
         status: ApplicationStatus.OFFER_ACCEPTED,
       },
       data: {
-        status: ApplicationStatus.OFFER_REJECTED,
+        status: ApplicationStatus.REJECTED,
       },
     })
 

--- a/apps/api/src/modules/job/job.service.ts
+++ b/apps/api/src/modules/job/job.service.ts
@@ -413,9 +413,9 @@ export class JobService {
     }
 
     if (
-      this.JobStatusToNumber(job.status) + 1 !=
+      this.JobStatusToNumber(job.status) + 1 !==
         this.JobStatusToNumber(updateJobStatus) &&
-      updateJobStatus != JobStatus.CANCELLED
+      updateJobStatus !== JobStatus.CANCELLED
     )
       // only allow to update status to next status (except cancelled)
       throw new ForbiddenException(

--- a/apps/api/src/modules/report/report.repository.ts
+++ b/apps/api/src/modules/report/report.repository.ts
@@ -59,11 +59,6 @@ export class ReportRepository {
     await this.prisma.application.updateMany({
       where: {
         jobId: jobId,
-        Job: {
-          status: {
-            in: JobStatus.CANCELLED,
-          },
-        },
         status: {
           in: [
             ApplicationStatus.PENDING,

--- a/apps/api/src/modules/report/report.repository.ts
+++ b/apps/api/src/modules/report/report.repository.ts
@@ -1,4 +1,4 @@
-import { JobStatus } from '@modela/database'
+import { ApplicationStatus, JobStatus } from '@modela/database'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -52,6 +52,29 @@ export class ReportRepository {
       },
       data: {
         status: JobStatus.CANCELLED,
+      },
+    })
+
+    //update application status
+    await this.prisma.application.updateMany({
+      where: {
+        jobId: jobId,
+        Job: {
+          status: {
+            in: JobStatus.CANCELLED,
+          },
+        },
+        status: {
+          in: [
+            ApplicationStatus.PENDING,
+            ApplicationStatus.OFFER_SENT,
+            ApplicationStatus.OFFER_ACCEPTED,
+          ],
+        },
+      },
+
+      data: {
+        status: ApplicationStatus.REJECTED,
       },
     })
     return { jobId: jobId }

--- a/apps/api/src/modules/user/profile/profile.controller.ts
+++ b/apps/api/src/modules/user/profile/profile.controller.ts
@@ -72,7 +72,7 @@ export class ProfileController {
   @ApiForbiddenResponse({ description: 'User is not an casting or actor' })
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiNotFoundResponse({ description: 'User not found' })
-  getProfileById(@Param('id') id: number) {
-    return this.profileService.getProfileById(+id)
+  getProfileById(@Param('id') id: number, @User() user: JwtDto) {
+    return this.profileService.getProfileById(+id, user)
   }
 }

--- a/apps/api/src/modules/user/profile/profile.service.ts
+++ b/apps/api/src/modules/user/profile/profile.service.ts
@@ -63,18 +63,15 @@ export class ProfileService {
     id: number,
     user: JwtDto,
   ): Promise<GetProfileForViewingDto> {
-    const TargetUser = await this.repository.getUserProfileById(id)
+    const targetUser = await this.repository.getUserProfileById(id)
 
-    if (!TargetUser) {
+    if (!targetUser) {
       throw new NotFoundException()
     }
-    if (user.userId !== id) {
-      // if user is not the owner of the profile
-      if (user.type === TargetUser.type) {
-        // user can't see other user's profile if they are the same type
-        throw new ForbiddenException()
-      }
+    if (user.userId !== id && user.type === targetUser.type) {
+      // user can't see other user's profile if they are the same type
+      throw new ForbiddenException()
     }
-    return TargetUser
+    return targetUser
   }
 }


### PR DESCRIPTION
## What did you do
- endpoint ```GET /profiles/:id``` add a feature that the same role can't view each other
- endpoint ```PUT /jobs/:id/status```
- add ForbiddenException when change JobStatus is not in order
- change ApplicationStatus of application in the job when changing JobStatus
![image](https://user-images.githubusercontent.com/48400275/224707631-49c4aa7e-823f-4da4-b0a8-5e2397fe391e.png)



## Demo
- https://dev.modela.miello.dev/
- login with any casting in one window
- login with actor that has resumes (maybe 1,2) in another window
- as casting create new job
- as actor apply that created job
- as casting change that JobStatus in order until "เสร็จสิ้นการคัดเลือก" (SELECTION_END)
- any pending actors will automatically change ApplicationStatus to "ไม่ผ่านการคัดเลือก" (REJECTED)
- also admin cancell job will change to REJECTED

## Limitation
- not have unit test yet
