### PR TITLE
[136] Implement reject job application API

### DIFF
--- a/apps/api/src/modules/job/application/application.controller.ts
+++ b/apps/api/src/modules/job/application/application.controller.ts
@@ -7,7 +7,7 @@ import {
   ResumeIdDto,
 } from '@modela/dtos'
 import { Controller, Get, Param } from '@nestjs/common'
-import { Body, Post, Query } from '@nestjs/common/decorators'
+import { Body, Post, Put, Query } from '@nestjs/common/decorators'
 import {
   ApiBadRequestResponse,
   ApiConflictResponse,
@@ -61,5 +61,30 @@ export class ApplicationController {
     @User() user: JwtDto,
   ) {
     return this.applicationService.applyJob(+id, body.resumeId, user.userId)
+  }
+
+  @Put('/:jobId/actors/:actorId/reject')
+  @UseAuthGuard(UserType.CASTING)
+  @ApiOperation({ summary: 'casting reject actor application' })
+  @ApiOkResponse()
+  @ApiBadRequestResponse({
+    description:
+      'actor didn’t apply for this job or application status is not pending',
+  })
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  @ApiForbiddenResponse({
+    description: 'User is not Casting or User is not the owner of this job',
+  })
+  rejectApplication(
+    @Param('jobId') jobId: string,
+    @Param('actorId') actorId: string,
+    @User() user: JwtDto,
+  ) {
+    return this.applicationService.rejectApplication(
+      +jobId,
+      +actorId,
+      user.userId,
+    )
   }
 }

--- a/apps/api/src/modules/job/application/application.repository.ts
+++ b/apps/api/src/modules/job/application/application.repository.ts
@@ -72,4 +72,11 @@ export class ApplicationRepository {
       },
     })
   }
+
+  async rejectApplication(applicationId: number) {
+    return await this.prisma.application.update({
+      where: { applicationId },
+      data: { status: ApplicationStatus.REJECTED },
+    })
+  }
 }

--- a/apps/api/src/modules/job/application/application.service.ts
+++ b/apps/api/src/modules/job/application/application.service.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationStatus,
   GetAppliedActorDto,
   GetAppliedActorQuery,
   JobStatus,
@@ -66,5 +67,27 @@ export class ApplicationService {
     return {
       applicationId: newApplication.applicationId,
     }
+  }
+
+  async rejectApplication(jobId: number, actorId: number, castingId: number) {
+    const job = await this.jobRepository.getBaseJobById(jobId)
+
+    if (!job) throw new NotFoundException('Job not found')
+
+    if (job.castingId !== castingId)
+      throw new ForbiddenException('User is not the owner of this job')
+
+    const application = await this.repository.getApplicationbyActorJob(
+      actorId,
+      jobId,
+    )
+
+    if (!application)
+      throw new BadRequestException(`Actor didn't apply for this job`)
+
+    if (application.status !== ApplicationStatus.PENDING)
+      throw new BadRequestException('Application is not pending')
+
+    this.repository.rejectApplication(application.applicationId)
   }
 }


### PR DESCRIPTION
## What did you do

<!--## For frontend please also paste the image of the part that you worked on-->

- Implement reject job application API with unit test

## Demo

<!--## Link to the page / API that you did in dev environment-->

- go to https://api-dev.modela.miello.dev/swagger#/application/ApplicationController_rejectApplication
- login as casting
- try to reject application 

(you can login as casting in frontend to create job and login as actor to apply for that job)
