### PR TITLE
[195] Implement edit resume API @PUT

### DIFF
--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -14,6 +14,7 @@ import {
   HttpCode,
   Param,
   Post,
+  Put,
 } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
@@ -45,6 +46,21 @@ export class ResumeController {
   @ApiOperation({ summary: 'adds resume to user profile' })
   createResume(@Body() postResumeDto: PostResumeDto, @User() user: JwtDto) {
     return this.resumeService.createResume(postResumeDto, user)
+  }
+
+  @Put(':resumeId')
+  @UseAuthGuard(UserType.ACTOR)
+  @ApiOkResponse()
+  @ApiUnauthorizedResponse({ description: 'User is not logged in' })
+  @ApiForbiddenResponse({ description: 'User is not an actor' })
+  @ApiNotFoundResponse({ description: 'Resume not found' })
+  @ApiOperation({ summary: 'updates resume from user profile' })
+  updateResume(
+    @Param('resumeId') resumeId: number,
+    @Body() postResumeDto: PostResumeDto,
+    @User() user: JwtDto,
+  ) {
+    return this.resumeService.updateResume(+resumeId, postResumeDto, user)
   }
 
   @Get()

--- a/apps/api/src/modules/resume/resume.controller.ts
+++ b/apps/api/src/modules/resume/resume.controller.ts
@@ -52,7 +52,9 @@ export class ResumeController {
   @UseAuthGuard(UserType.ACTOR)
   @ApiOkResponse()
   @ApiUnauthorizedResponse({ description: 'User is not logged in' })
-  @ApiForbiddenResponse({ description: 'User is not an actor' })
+  @ApiForbiddenResponse({
+    description: 'User is not an actor or is not the owner of resume',
+  })
   @ApiNotFoundResponse({ description: 'Resume not found' })
   @ApiOperation({ summary: 'updates resume from user profile' })
   updateResume(

--- a/apps/api/src/modules/resume/resume.respository.ts
+++ b/apps/api/src/modules/resume/resume.respository.ts
@@ -59,4 +59,12 @@ export class ResumeRepository {
       return deletedResume
     }
   }
+
+  async updateResume(resumeId: number, postResumeDto: PostResumeDto) {
+    const resume = await this.prisma.resume.update({
+      where: { resumeId },
+      data: postResumeDto,
+    })
+    return resume
+  }
 }

--- a/apps/api/src/modules/resume/resume.service.ts
+++ b/apps/api/src/modules/resume/resume.service.ts
@@ -15,6 +15,24 @@ export class ResumeService {
     return this.repository.createResume(postResumeDto, user.userId)
   }
 
+  async updateResume(
+    resumeId: number,
+    postResumeDto: PostResumeDto,
+    user: JwtDto,
+  ) {
+    const resume = await this.repository.getResumeById(resumeId)
+    if (!resume) throw new NotFoundException()
+    if (resume.actorId !== user.userId)
+      throw new ForbiddenException('You are not the owner of this resume')
+
+    const updatedResume = await this.repository.updateResume(
+      resumeId,
+      postResumeDto,
+    )
+
+    return updatedResume
+  }
+
   async getResumeById(resumeId: number, user: JwtDto) {
     const resume = await this.repository.getResumeById(resumeId)
     if (!resume) {


### PR DESCRIPTION
## What did you do

- implemented API endpoint for editing resume

## Demo
- go to swagger
- login as actor
- create a resume, here's a sample.
```
{
  "name": "HELLO PLS UPDATE ME",
  "resumeUrl": "google.com"
}
```
- open db:studio to check if the resume is there
- update the resume (the ID should be 11), here's some samples
WORKING
```
{
  "name": "updated",
  "resumeUrl": "aaaa.com"
}
```
ERROR
```
{
  "name": "this should not work",
  "resumeUrl": "this is not URL"
}
```
- also try editing other's resume