### PR TITLE
[150] Implement cancel applied job API @PUT

### DIFF
--- a/apps/api/src/modules/job/application/application.controller.ts
+++ b/apps/api/src/modules/job/application/application.controller.ts
@@ -87,4 +87,19 @@ export class ApplicationController {
       user.userId,
     )
   }
+
+  @Put('/:jobId/application/cancel')
+  @UseAuthGuard(UserType.ACTOR)
+  @ApiOperation({ summary: 'Cancels application for a job' })
+  @ApiOkResponse()
+  @ApiBadRequestResponse({
+    description:
+      'actor didn’t apply for this job or application status is not pending',
+  })
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  @ApiForbiddenResponse({ description: 'User is not Actor' })
+  cancelApplication(@Param('jobId') jobId: string, @User() user: JwtDto) {
+    return this.applicationService.cancelApplication(+jobId, user.userId)
+  }
 }

--- a/apps/api/src/modules/job/application/application.controller.ts
+++ b/apps/api/src/modules/job/application/application.controller.ts
@@ -99,7 +99,7 @@ export class ApplicationController {
   @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiNotFoundResponse({ description: 'Job not found' })
   @ApiForbiddenResponse({ description: 'User is not Actor' })
-  cancelApplication(@Param('jobId') jobId: string, @User() user: JwtDto) {
-    return this.applicationService.cancelApplication(+jobId, user.userId)
+  async cancelApplication(@Param('jobId') jobId: string, @User() user: JwtDto) {
+    return await this.applicationService.cancelApplication(+jobId, user.userId)
   }
 }

--- a/apps/api/src/modules/job/application/application.repository.ts
+++ b/apps/api/src/modules/job/application/application.repository.ts
@@ -73,6 +73,12 @@ export class ApplicationRepository {
     })
   }
 
+  async deleteApplication(applicationId: number) {
+    return await this.prisma.application.delete({
+      where: { applicationId },
+    })
+  }
+
   async rejectApplication(applicationId: number) {
     return await this.prisma.application.update({
       where: { applicationId },

--- a/apps/api/src/modules/job/application/application.service.ts
+++ b/apps/api/src/modules/job/application/application.service.ts
@@ -90,4 +90,23 @@ export class ApplicationService {
 
     this.repository.rejectApplication(application.applicationId)
   }
+
+  async cancelApplication(jobId: number, actorId: number) {
+    const job = await this.jobRepository.getBaseJobById(jobId)
+
+    if (!job) throw new NotFoundException('Job not found')
+    if (job.status !== JobStatus.SELECTING) {
+      throw new BadRequestException('Job is not selecting')
+    }
+
+    const application = await this.repository.getApplicationbyActorJob(
+      actorId,
+      jobId,
+    )
+
+    if (!application)
+      throw new BadRequestException(`You didn't apply for this job`)
+
+    this.repository.deleteApplication(application.applicationId)
+  }
 }

--- a/apps/api/src/modules/job/application/application.service.ts
+++ b/apps/api/src/modules/job/application/application.service.ts
@@ -107,6 +107,6 @@ export class ApplicationService {
     if (!application)
       throw new BadRequestException(`You didn't apply for this job`)
 
-    this.repository.deleteApplication(application.applicationId)
+    await this.repository.deleteApplication(application.applicationId)
   }
 }


### PR DESCRIPTION
## What did you do

- implemented API which allows actor to cancel (completely delete) application for jobs

## Demo

- go to swagger and login as caster with application already on prisma studio
- try canceling application with their respective `jobId`
- should be a bad request if haven't applied or job is not searching.
- try arbitrary `jobId` (very high numbers for example) and see if it returns 404 for job not found
- the application should be deleted otherwise.
