### PR TITLE
[171][174] Implement accept-reject refund request API @PUT

### DIFF
--- a/apps/api/src/modules/debit/debit.module.ts
+++ b/apps/api/src/modules/debit/debit.module.ts
@@ -3,12 +3,13 @@ import { PrismaModule } from 'src/database/prisma.module'
 
 import { ApplicationModule } from '../job/application/application.module'
 import { JobModule } from '../job/job.module'
+import { RefundModule } from '../refund/refund.module'
 import { DebitController } from './debit.controller'
 import { DebitRepository } from './debit.repository'
 import { DebitService } from './debit.service'
 
 @Module({
-  imports: [PrismaModule, ApplicationModule, JobModule],
+  imports: [PrismaModule, ApplicationModule, JobModule, RefundModule],
   controllers: [DebitController],
   providers: [DebitService, DebitRepository],
 })

--- a/apps/api/src/modules/debit/debit.repository.ts
+++ b/apps/api/src/modules/debit/debit.repository.ts
@@ -18,13 +18,6 @@ export class DebitRepository {
     })
   }
 
-  // TODO: any one who work with refund API should move this to refund repository
-  async getRefundByApplicationId(applicationId: number) {
-    return await this.prisma.refund.findFirst({
-      where: { applicationId },
-    })
-  }
-
   async getPendingJobsDebits(): Promise<GetPendingJobsDebitsDto[]> {
     const jobs = await this.prisma.job.findMany({
       where: {

--- a/apps/api/src/modules/debit/debit.service.spec.ts
+++ b/apps/api/src/modules/debit/debit.service.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from 'src/database/prisma.service'
 
 import { ApplicationRepository } from '../job/application/application.repository'
 import { JobRepository } from '../job/job.repository'
+import { RefundRepository } from '../refund/refund.repository'
 import { DebitRepository } from './debit.repository'
 import { DebitService } from './debit.service'
 
@@ -13,6 +14,7 @@ describe('DebitService', () => {
   let repository: DebitRepository
   let jobRepository: JobRepository
   let applicationRepository: ApplicationRepository
+  let refundRepository: RefundRepository
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,7 @@ describe('DebitService', () => {
         PrismaService,
         JobRepository,
         ApplicationRepository,
+        RefundRepository,
       ],
     }).compile()
 
@@ -31,6 +34,7 @@ describe('DebitService', () => {
     applicationRepository = module.get<ApplicationRepository>(
       ApplicationRepository,
     )
+    refundRepository = module.get<RefundRepository>(RefundRepository)
   })
 
   it('should be defined', () => {
@@ -58,7 +62,9 @@ describe('DebitService', () => {
             })
             .get(),
         )
-      jest.spyOn(repository, 'getRefundByApplicationId').mockResolvedValue(null)
+      jest
+        .spyOn(refundRepository, 'getRefundByApplicationId')
+        .mockResolvedValue(null)
 
       jest.spyOn(repository, 'markAsPaid').mockResolvedValue(null)
     })
@@ -118,7 +124,7 @@ describe('DebitService', () => {
 
     it('should throw bad request error if application is already refunded', async () => {
       jest
-        .spyOn(repository, 'getRefundByApplicationId')
+        .spyOn(refundRepository, 'getRefundByApplicationId')
         .mockResolvedValue(mock('refund').get())
 
       await expect(

--- a/apps/api/src/modules/debit/debit.service.ts
+++ b/apps/api/src/modules/debit/debit.service.ts
@@ -11,6 +11,7 @@ import {
 
 import { ApplicationRepository } from '../job/application/application.repository'
 import { JobRepository } from '../job/job.repository'
+import { RefundRepository } from '../refund/refund.repository'
 import { DebitRepository } from './debit.repository'
 
 @Injectable()
@@ -19,6 +20,7 @@ export class DebitService {
     private repository: DebitRepository,
     private applicationRepository: ApplicationRepository,
     private jobRepository: JobRepository,
+    private refundRepository: RefundRepository,
   ) {}
 
   async markAsPaid(jobId: number, actorId: number) {
@@ -36,7 +38,7 @@ export class DebitService {
     if (application.isPaid)
       throw new BadRequestException('Already mark this transaction')
 
-    const refund = await this.repository.getRefundByApplicationId(
+    const refund = await this.refundRepository.getRefundByApplicationId(
       application.applicationId,
     )
     if (refund) throw new BadRequestException('Already refund')

--- a/apps/api/src/modules/job/application/application.repository.ts
+++ b/apps/api/src/modules/job/application/application.repository.ts
@@ -100,13 +100,4 @@ export class ApplicationRepository {
     })
     return
   }
-
-  async getApplicationbyActorJobId(actorId: number, jobId: number) {
-    return await this.prisma.application.findFirst({
-      where: {
-        actorId,
-        jobId,
-      },
-    })
-  }
 }

--- a/apps/api/src/modules/job/application/application.repository.ts
+++ b/apps/api/src/modules/job/application/application.repository.ts
@@ -100,4 +100,13 @@ export class ApplicationRepository {
     })
     return
   }
+
+  async getApplicationbyActorJobId(actorId: number, jobId: number) {
+    return await this.prisma.application.findFirst({
+      where: {
+        actorId,
+        jobId,
+      },
+    })
+  }
 }

--- a/apps/api/src/modules/refund/refund.controller.ts
+++ b/apps/api/src/modules/refund/refund.controller.ts
@@ -1,0 +1,37 @@
+import { UserType } from '@modela/database'
+import { Controller, Param, Put } from '@nestjs/common'
+import {
+  ApiBadRequestResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+
+import { UseAuthGuard } from '../auth/misc/jwt.decorator'
+import { RefundService } from './refund.service'
+
+@ApiTags('refunds')
+@Controller('refunds')
+export class RefundController {
+  constructor(private readonly refundService: RefundService) {}
+
+  @Put('/jobs/:jobId/actors/:actorId/accept')
+  @UseAuthGuard(UserType.ADMIN)
+  @ApiBadRequestResponse({
+    description: 'no refund request of this actor in this job',
+  })
+  @ApiUnauthorizedResponse({ description: 'User is not logged in' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  @ApiForbiddenResponse({ description: 'User is not an admin' })
+  @ApiOkResponse()
+  @ApiOperation({ summary: 'admin accept refund request' })
+  acceptRefund(
+    @Param('jobId') jobId: number,
+    @Param('actorId') actorId: number,
+  ) {
+    return this.refundService.acceptRefund(+jobId, +actorId)
+  }
+}

--- a/apps/api/src/modules/refund/refund.controller.ts
+++ b/apps/api/src/modules/refund/refund.controller.ts
@@ -34,4 +34,21 @@ export class RefundController {
   ) {
     return this.refundService.acceptRefund(+jobId, +actorId)
   }
+
+  @Put('/jobs/:jobId/actors/:actorId/reject')
+  @UseAuthGuard(UserType.ADMIN)
+  @ApiBadRequestResponse({
+    description: 'no refund request of this actor in this job',
+  })
+  @ApiUnauthorizedResponse({ description: 'User is not logged in' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  @ApiForbiddenResponse({ description: 'User is not an admin' })
+  @ApiOkResponse()
+  @ApiOperation({ summary: 'admin reject refund request' })
+  rejectRefund(
+    @Param('jobId') jobId: number,
+    @Param('actorId') actorId: number,
+  ) {
+    return this.refundService.rejectRefund(+jobId, +actorId)
+  }
 }

--- a/apps/api/src/modules/refund/refund.module.ts
+++ b/apps/api/src/modules/refund/refund.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+import { PrismaModule } from 'src/database/prisma.module'
+
+import { RefundController } from './refund.controller'
+import { RefundRepository } from './refund.repository'
+import { RefundService } from './refund.service'
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [RefundController],
+  providers: [RefundService, RefundRepository],
+})
+export class RefundModule {}

--- a/apps/api/src/modules/refund/refund.module.ts
+++ b/apps/api/src/modules/refund/refund.module.ts
@@ -3,12 +3,13 @@ import { PrismaModule } from 'src/database/prisma.module'
 
 import { ApplicationModule } from '../job/application/application.module'
 import { JobModule } from '../job/job.module'
+import { NotificationModule } from '../notification/notification.module'
 import { RefundController } from './refund.controller'
 import { RefundRepository } from './refund.repository'
 import { RefundService } from './refund.service'
 
 @Module({
-  imports: [PrismaModule, ApplicationModule, JobModule],
+  imports: [PrismaModule, ApplicationModule, JobModule, NotificationModule],
   controllers: [RefundController],
   providers: [RefundService, RefundRepository],
   exports: [RefundRepository],

--- a/apps/api/src/modules/refund/refund.module.ts
+++ b/apps/api/src/modules/refund/refund.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common'
 import { PrismaModule } from 'src/database/prisma.module'
 
+import { ApplicationModule } from '../job/application/application.module'
+import { JobModule } from '../job/job.module'
 import { RefundController } from './refund.controller'
 import { RefundRepository } from './refund.repository'
 import { RefundService } from './refund.service'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ApplicationModule, JobModule],
   controllers: [RefundController],
   providers: [RefundService, RefundRepository],
+  exports: [RefundRepository],
 })
 export class RefundModule {}

--- a/apps/api/src/modules/refund/refund.repository.ts
+++ b/apps/api/src/modules/refund/refund.repository.ts
@@ -1,3 +1,4 @@
+import { RefundStatus } from '@modela/database'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -11,8 +12,12 @@ export class RefundRepository {
     })
   }
 
-  async acceptRefund(jobId: number, actorId: number) {
-    //TODO accept refund
-    return { jobId, actorId }
+  async acceptRefund(refundId: number) {
+    //update refund status to accepted
+    const updatedRefund = await this.prisma.refund.update({
+      where: { refundId },
+      data: { refundStatus: RefundStatus.ACCEPTED },
+    })
+    return updatedRefund
   }
 }

--- a/apps/api/src/modules/refund/refund.repository.ts
+++ b/apps/api/src/modules/refund/refund.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from 'src/database/prisma.service'
+
+@Injectable()
+export class RefundRepository {
+  constructor(private prisma: PrismaService) {}
+
+  async getRefundByApplicationId(applicationId: number) {
+    return await this.prisma.refund.findFirst({
+      where: { applicationId },
+    })
+  }
+
+  async acceptRefund(jobId: number, actorId: number) {
+    //TODO accept refund
+    return { jobId, actorId }
+  }
+}

--- a/apps/api/src/modules/refund/refund.repository.ts
+++ b/apps/api/src/modules/refund/refund.repository.ts
@@ -20,4 +20,12 @@ export class RefundRepository {
     })
     return updatedRefund
   }
+
+  async rejectRefund(refundId: number) {
+    //delete refund
+    const deletedRefund = await this.prisma.refund.delete({
+      where: { refundId },
+    })
+    return deletedRefund
+  }
 }

--- a/apps/api/src/modules/refund/refund.repository.ts
+++ b/apps/api/src/modules/refund/refund.repository.ts
@@ -7,7 +7,7 @@ export class RefundRepository {
   constructor(private prisma: PrismaService) {}
 
   async getRefundByApplicationId(applicationId: number) {
-    return await this.prisma.refund.findFirst({
+    return await this.prisma.refund.findUnique({
       where: { applicationId },
     })
   }

--- a/apps/api/src/modules/refund/refund.service.spec.ts
+++ b/apps/api/src/modules/refund/refund.service.spec.ts
@@ -1,21 +1,41 @@
-//import { mock } from '@modela/database'
 import { Test, TestingModule } from '@nestjs/testing'
 import { PrismaService } from 'src/database/prisma.service'
 
+import { ApplicationRepository } from '../job/application/application.repository'
+import { JobRepository } from '../job/job.repository'
+import { NotificationModule } from '../notification/notification.module'
 import { RefundRepository } from './refund.repository'
 import { RefundService } from './refund.service'
 
 describe('RefundService', () => {
   let service: RefundService
-  //let repository: RefundRepository
-
+  /*
+  let repository: RefundRepository
+  let jobRepository: JobRepository
+  let applicationRepository: ApplicationRepository
+  let notificationService: NotificationService
+  */
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RefundService, RefundRepository, PrismaService],
+      providers: [
+        RefundService,
+        RefundRepository,
+        PrismaService,
+        JobRepository,
+        ApplicationRepository,
+      ],
+      imports: [NotificationModule],
     }).compile()
 
     service = module.get<RefundService>(RefundService)
-    //repository = module.get<RefundRepository>(RefundRepository)
+    /*
+    repository = module.get<RefundRepository>(RefundRepository)
+    jobRepository = module.get<JobRepository>(JobRepository)
+    applicationRepository = module.get<ApplicationRepository>(
+      ApplicationRepository,
+    )
+    notificationService = module.get<NotificationService>(NotificationService)
+    */
   })
 
   it('should be defined', () => {

--- a/apps/api/src/modules/refund/refund.service.spec.ts
+++ b/apps/api/src/modules/refund/refund.service.spec.ts
@@ -1,0 +1,24 @@
+//import { mock } from '@modela/database'
+import { Test, TestingModule } from '@nestjs/testing'
+import { PrismaService } from 'src/database/prisma.service'
+
+import { RefundRepository } from './refund.repository'
+import { RefundService } from './refund.service'
+
+describe('RefundService', () => {
+  let service: RefundService
+  //let repository: RefundRepository
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RefundService, RefundRepository, PrismaService],
+    }).compile()
+
+    service = module.get<RefundService>(RefundService)
+    //repository = module.get<RefundRepository>(RefundRepository)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/apps/api/src/modules/refund/refund.service.ts
+++ b/apps/api/src/modules/refund/refund.service.ts
@@ -24,8 +24,10 @@ export class RefundService {
     if (!job) throw new NotFoundException('Job not found')
 
     //find applicationId by jobId and actorId
-    const application =
-      await this.applicationReposity.getApplicationbyActorJobId(actorId, jobId)
+    const application = await this.applicationReposity.getApplicationbyActorJob(
+      actorId,
+      jobId,
+    )
     if (!application)
       throw new BadRequestException('no application of this actor in this job')
 

--- a/apps/api/src/modules/refund/refund.service.ts
+++ b/apps/api/src/modules/refund/refund.service.ts
@@ -1,12 +1,44 @@
-import { Injectable } from '@nestjs/common'
+import { RefundStatus } from '@modela/database'
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 
+import { ApplicationRepository } from '../job/application/application.repository'
+import { JobRepository } from '../job/job.repository'
 import { RefundRepository } from './refund.repository'
 
 @Injectable()
 export class RefundService {
-  constructor(private repository: RefundRepository) {}
+  constructor(
+    private repository: RefundRepository,
+    private jobRepository: JobRepository,
+    private applicationReposity: ApplicationRepository,
+  ) {}
 
   async acceptRefund(jobId: number, actorId: number) {
-    return await this.repository.acceptRefund(jobId, actorId)
+    const job = await this.jobRepository.getBaseJobById(jobId)
+    if (!job) throw new NotFoundException('Job not found')
+
+    //find applicationId by jobId and actorId
+    const application =
+      await this.applicationReposity.getApplicationbyActorJobId(actorId, jobId)
+    if (!application)
+      throw new BadRequestException('no application of this actor in this job')
+
+    //get refund by applicationId
+    const refund = await this.repository.getRefundByApplicationId(
+      application.applicationId,
+    )
+    if (!refund)
+      throw new BadRequestException(
+        'no refund request of this actor in this job',
+      )
+
+    if (refund.refundStatus !== RefundStatus.PENDING)
+      throw new BadRequestException('refund status is not pending')
+
+    return await this.repository.acceptRefund(refund.refundId)
   }
 }

--- a/apps/api/src/modules/refund/refund.service.ts
+++ b/apps/api/src/modules/refund/refund.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common'
+
+import { RefundRepository } from './refund.repository'
+
+@Injectable()
+export class RefundService {
+  constructor(private repository: RefundRepository) {}
+
+  async acceptRefund(jobId: number, actorId: number) {
+    return await this.repository.acceptRefund(jobId, actorId)
+  }
+}


### PR DESCRIPTION
## What did you do
- create refund module folder in backend
- move getRefundByApplicationId from debit to refund repository

- add ```PUT /refunds/jobs/:jobId/actors/:actorId/accept``` for admin to accept refund request
- send notification APPROVE_REFUND to actor and casting

- add ```PUT /refunds/jobs/:jobId/actors/:actorId/reject``` for admin to reject refund request
- send notification REJECT_REFUND to casting

## Demo
- since not have view pending refund, need to inspect database of dev
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login as any admin
- https://api-dev.modela.miello.dev/swagger#/refunds/RefundController_acceptRefund
- accept some refund, view in db status is change from PENDING to ACCEPT and should send noti to actor and casting
- https://api-dev.modela.miello.dev/swagger#/refunds/RefundController_rejectRefund
- reject some refund, view in db that refund should be deleted and should send noti to casting

## Limitation
- not have unit test yet
