### PR TITLE
[189] [192] Implement actor work history in actor and casting view API @GET

### DIFF
--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -1,4 +1,5 @@
 import {
+  GetJobCardDto,
   GetUserDto,
   JwtDto,
   PendingUserDto,
@@ -54,5 +55,18 @@ export class UserController {
     @Body() updateUserStatusDto: UpdateUserStatusDto,
   ) {
     return this.userService.updateUserStatus(+id, updateUserStatusDto)
+  }
+
+  @Get(':id/history')
+  @UseAuthGuard()
+  @ApiOperation({ summary: 'get work history for casting and actor' })
+  @ApiOkResponse({ type: GetJobCardDto })
+  @ApiNotFoundResponse({ description: 'user not found' })
+  getUsersWorkHistory(@Param('id') ParamId: number, @User() user: JwtDto) {
+    return this.userService.getUsersWorkHistory(
+      +ParamId,
+      user.userId,
+      user.type,
+    )
   }
 }

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -66,10 +66,6 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'user not found' })
   @ApiForbiddenResponse({ description: 'User is not casting or not this user' })
   getUsersWorkHistory(@Param('id') ParamId: number, @User() user: JwtDto) {
-    return this.userService.getUsersWorkHistory(
-      +ParamId,
-      user.userId,
-      user.type,
-    )
+    return this.userService.getUserWorkHistory(+ParamId, user.userId, user.type)
   }
 }

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
 import { Body, Controller, Get, Param, Put } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -59,9 +60,11 @@ export class UserController {
 
   @Get(':id/history')
   @UseAuthGuard()
+  @ApiUnauthorizedResponse({ description: 'User is not login' })
   @ApiOperation({ summary: 'get work history for casting and actor' })
   @ApiOkResponse({ type: GetJobCardDto })
   @ApiNotFoundResponse({ description: 'user not found' })
+  @ApiForbiddenResponse({ description: 'User is not casting or not this user' })
   getUsersWorkHistory(@Param('id') ParamId: number, @User() user: JwtDto) {
     return this.userService.getUsersWorkHistory(
       +ParamId,

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -151,7 +151,9 @@ export class UserRepository {
     let returnJobs = jobs.map(
       // assume that there is only one filtered application for each job
       (job) =>
-        job.Application[0].Refund.refundStatus !== RefundStatus.ACCEPTED && {
+        (job.Application[0].Refund
+          ? job.Application[0].Refund.refundStatus !== RefundStatus.ACCEPTED
+          : true) && {
           jobId: job.jobId,
           title: job.title,
           companyName: job.Casting.companyName,

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -3,7 +3,6 @@ import {
   Casting,
   JobStatus,
   Prisma,
-  RefundStatus,
   User,
   UserStatus,
 } from '@modela/database'
@@ -127,6 +126,7 @@ export class UserRepository {
           some: {
             actorId: paramId,
             status: ApplicationStatus.OFFER_ACCEPTED,
+            Refund: null,
           },
         },
       },
@@ -147,29 +147,20 @@ export class UserRepository {
         },
       },
     })
-
-    let returnJobs = jobs.map(
-      // assume that there is only one filtered application for each job
-      (job) =>
-        (job.Application[0].Refund
-          ? job.Application[0].Refund.refundStatus !== RefundStatus.ACCEPTED
-          : true) && {
-          jobId: job.jobId,
-          title: job.title,
-          companyName: job.Casting.companyName,
-          description: job.description,
-          status: job.status,
-          actorCount: job.actorCount,
-          gender: job.gender,
-          wage: job.wage,
-          applicationDeadline: job.applicationDeadline,
-          jobCastingImageUrl: job.Casting.User.profileImageUrl,
-          castingId: job.castingId,
-          castingName: job.Casting.User.firstName,
-        },
-    )
-    // remove undefined
-    returnJobs = returnJobs.filter((job) => job)
+    const returnJobs = jobs.map((job) => ({
+      jobId: job.jobId,
+      title: job.title,
+      companyName: job.Casting.companyName,
+      description: job.description,
+      status: job.status,
+      actorCount: job.actorCount,
+      gender: job.gender,
+      wage: job.wage,
+      applicationDeadline: job.applicationDeadline,
+      jobCastingImageUrl: job.Casting.User.profileImageUrl,
+      castingId: job.castingId,
+      castingName: job.Casting.User.firstName,
+    }))
     return returnJobs
   }
 

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -3,6 +3,7 @@ import {
   Casting,
   JobStatus,
   Prisma,
+  RefundStatus,
   User,
   UserStatus,
 } from '@modela/database'
@@ -135,24 +136,38 @@ export class UserRepository {
             User: true,
           },
         },
+        Application: {
+          where: {
+            actorId: paramId,
+            status: ApplicationStatus.OFFER_ACCEPTED,
+          },
+          include: {
+            Refund: true,
+          },
+        },
       },
     })
 
-    const returnJobs = jobs.map((job) => ({
-      jobId: job.jobId,
-      title: job.title,
-      companyName: job.Casting.companyName,
-      description: job.description,
-      status: job.status,
-      actorCount: job.actorCount,
-      gender: job.gender,
-      wage: job.wage,
-      applicationDeadline: job.applicationDeadline,
-      jobCastingImageUrl: job.Casting.User.profileImageUrl,
-      castingId: job.castingId,
-      castingName: job.Casting.User.firstName,
-    }))
-
+    let returnJobs = jobs.map(
+      // assume that there is only one filtered application for each job
+      (job) =>
+        job.Application[0].Refund.refundStatus !== RefundStatus.ACCEPTED && {
+          jobId: job.jobId,
+          title: job.title,
+          companyName: job.Casting.companyName,
+          description: job.description,
+          status: job.status,
+          actorCount: job.actorCount,
+          gender: job.gender,
+          wage: job.wage,
+          applicationDeadline: job.applicationDeadline,
+          jobCastingImageUrl: job.Casting.User.profileImageUrl,
+          castingId: job.castingId,
+          castingName: job.Casting.User.firstName,
+        },
+    )
+    // remove undefined
+    returnJobs = returnJobs.filter((job) => job)
     return returnJobs
   }
 

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -122,7 +122,6 @@ export class UserRepository {
       },
       where: {
         status: JobStatus.FINISHED,
-        //filter jobs that the actor has applied to and accepted the offer
         Application: {
           some: {
             actorId: paramId,

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -1,5 +1,16 @@
-import { Casting, Prisma, User, UserStatus } from '@modela/database'
-import { PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
+import {
+  ApplicationStatus,
+  Casting,
+  JobStatus,
+  Prisma,
+  User,
+  UserStatus,
+} from '@modela/database'
+import {
+  GetJobCardDto,
+  PendingUserDto,
+  UpdateUserStatusDto,
+} from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/database/prisma.service'
 
@@ -102,5 +113,83 @@ export class UserRepository {
       },
     }
     return respondUpdatedUser
+  }
+
+  async getActorsWorkHistory(paramId: number): Promise<GetJobCardDto[]> {
+    const jobs = await this.prisma.job.findMany({
+      orderBy: {
+        jobId: Prisma.SortOrder.desc,
+      },
+      where: {
+        status: JobStatus.FINISHED,
+        //filter jobs that the actor has applied to and accepted the offer
+        Application: {
+          some: {
+            actorId: paramId,
+            status: ApplicationStatus.OFFER_ACCEPTED,
+          },
+        },
+      },
+      include: {
+        Casting: {
+          include: {
+            User: true,
+          },
+        },
+      },
+    })
+
+    const returnJobs = jobs.map((job) => ({
+      jobId: job.jobId,
+      title: job.title,
+      companyName: job.Casting.companyName,
+      description: job.description,
+      status: job.status,
+      actorCount: job.actorCount,
+      gender: job.gender,
+      wage: job.wage,
+      applicationDeadline: job.applicationDeadline,
+      jobCastingImageUrl: job.Casting.User.profileImageUrl,
+      castingId: job.castingId,
+      castingName: job.Casting.User.firstName,
+    }))
+
+    return returnJobs
+  }
+
+  async getCastingWorkHistory(paramId: number): Promise<GetJobCardDto[]> {
+    const jobs = await this.prisma.job.findMany({
+      orderBy: {
+        jobId: Prisma.SortOrder.desc,
+      },
+      where: {
+        castingId: paramId,
+        status: JobStatus.FINISHED,
+      },
+      include: {
+        Casting: {
+          include: {
+            User: true,
+          },
+        },
+      },
+    })
+
+    const returnJobs = jobs.map((job) => ({
+      jobId: job.jobId,
+      title: job.title,
+      companyName: job.Casting.companyName,
+      description: job.description,
+      status: job.status,
+      actorCount: job.actorCount,
+      gender: job.gender,
+      wage: job.wage,
+      applicationDeadline: job.applicationDeadline,
+      jobCastingImageUrl: job.Casting.User.profileImageUrl,
+      castingId: job.castingId,
+      castingName: job.Casting.User.firstName,
+    }))
+
+    return returnJobs
   }
 }

--- a/apps/api/src/modules/user/user.service.spec.ts
+++ b/apps/api/src/modules/user/user.service.spec.ts
@@ -26,4 +26,6 @@ describe('UserService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined()
   })
+
+  //TODO: write test for getUserHistory
 })

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -89,7 +89,7 @@ export class UserService {
 
       result = await this.repository.getActorsWorkHistory(paramId)
     } else if (targetUser.type === UserType.CASTING) {
-      if (userType === UserType.CASTING && userId !== paramId)
+      if (userId !== paramId)
         throw new BadRequestException('Cannot get other casting work history')
 
       result = await this.repository.getCastingWorkHistory(paramId)

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -74,7 +74,7 @@ export class UserService {
     return updatedUser
   }
 
-  async getUsersWorkHistory(
+  async getUserWorkHistory(
     paramId: number,
     userId: number,
     userType: UserType,

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -8,6 +8,7 @@ import {
 import { Injectable } from '@nestjs/common'
 import {
   BadRequestException,
+  ForbiddenException,
   NotFoundException,
 } from '@nestjs/common/exceptions'
 
@@ -85,16 +86,16 @@ export class UserService {
     let result: GetJobCardDto[] = []
     if (targetUser.type === UserType.ACTOR) {
       if (userType === UserType.ACTOR && userId !== paramId)
-        throw new BadRequestException('Cannot get other actor work history')
+        throw new ForbiddenException('Cannot get other actor work history')
 
       result = await this.repository.getActorsWorkHistory(paramId)
     } else if (targetUser.type === UserType.CASTING) {
       if (userId !== paramId)
-        throw new BadRequestException('Cannot get other casting work history')
+        throw new ForbiddenException('Cannot get other casting work history')
 
       result = await this.repository.getCastingWorkHistory(paramId)
     } else {
-      throw new BadRequestException('Invalid user type')
+      throw new ForbiddenException('Invalid user type')
     }
 
     return result

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,5 +1,10 @@
-import { UserStatus } from '@modela/database'
-import { GetUserDto, PendingUserDto, UpdateUserStatusDto } from '@modela/dtos'
+import { UserStatus, UserType } from '@modela/database'
+import {
+  GetJobCardDto,
+  GetUserDto,
+  PendingUserDto,
+  UpdateUserStatusDto,
+} from '@modela/dtos'
 import { Injectable } from '@nestjs/common'
 import {
   BadRequestException,
@@ -66,5 +71,32 @@ export class UserService {
       updateUserStatusDto,
     )
     return updatedUser
+  }
+
+  async getUsersWorkHistory(
+    paramId: number,
+    userId: number,
+    userType: UserType,
+  ): Promise<GetJobCardDto[]> {
+    //check if user exist
+    const targetUser = await this.repository.getUserById(paramId)
+    if (!targetUser) throw new NotFoundException()
+
+    let result: GetJobCardDto[] = []
+    if (targetUser.type === UserType.ACTOR) {
+      if (userType === UserType.ACTOR && userId !== paramId)
+        throw new BadRequestException('Cannot get other actor work history')
+
+      result = await this.repository.getActorsWorkHistory(paramId)
+    } else if (targetUser.type === UserType.CASTING) {
+      if (userType === UserType.CASTING && userId !== paramId)
+        throw new BadRequestException('Cannot get other casting work history')
+
+      result = await this.repository.getCastingWorkHistory(paramId)
+    } else {
+      throw new BadRequestException('Invalid user type')
+    }
+
+    return result
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       eslint-config-custom: link:packages/eslint-config-custom
       husky: 8.0.3
       lint-staged: 13.1.0
-      prettier: 2.8.4
+      prettier: 2.8.7
       tsconfig: link:packages/tsconfig
       turbo: 1.7.0
 
@@ -233,10 +233,10 @@ importers:
     devDependencies:
       '@types/jest': 29.2.4
       dotenv-cli: 7.0.0
-      jest: 29.3.1_2263m44mchjafa7bz7l52hbcpa
+      jest: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
       prisma: 4.9.0
       prisma-dbml-generator: 0.10.0
-      ts-node: 10.9.1_cin3sed6ohfsopbmt6orxeb4o4
+      ts-node: 10.9.1_bdgp3l2zgaopogaavxusmetvge
       tsconfig: link:../tsconfig
       typescript: 4.9.5
 
@@ -278,8 +278,8 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.48.2_vea4hc5js2bfzj7uy52rojsfym
       eslint: 7.32.0
       eslint-config-prettier: 8.6.0_eslint@7.32.0
-      eslint-config-turbo: 0.0.8_eslint@7.32.0
-      eslint-plugin-prettier: 4.2.1_2fbugv7hbzbahj5qm3ztcno6by
+      eslint-config-turbo: 1.8.6_eslint@7.32.0
+      eslint-plugin-prettier: 4.2.1_5772kamwcemxmoyngveol5ys3m
       eslint-plugin-simple-import-sort: 9.0.0_eslint@7.32.0
       typescript: 4.9.4
 
@@ -5560,13 +5560,13 @@ packages:
       eslint: 8.32.0
     dev: true
 
-  /eslint-config-turbo/0.0.8_eslint@7.32.0:
-    resolution: {integrity: sha512-ijj6uv0QX2kWahg3OYnTK1/q4MueXsqY2uE4MP9yeUA5CzVhL7GU+biKlv1BfMMqPltixHUcpZoW4yyNLCnMiw==}
+  /eslint-config-turbo/1.8.6_eslint@7.32.0:
+    resolution: {integrity: sha512-LSMqrHmFeQcYRuBnzrzw+B2bJ3+o8wxPkRwfK0Y+SSLsq2F/niRJ2kqB8j4uOSCfxybHHpFEB2CgUpQiiyfeoQ==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 0.0.8_eslint@7.32.0
+      eslint-plugin-turbo: 1.8.6_eslint@7.32.0
     dev: true
 
   /eslint-import-resolver-node/0.3.7:
@@ -5682,7 +5682,7 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-prettier/4.2.1_2fbugv7hbzbahj5qm3ztcno6by:
+  /eslint-plugin-prettier/4.2.1_5772kamwcemxmoyngveol5ys3m:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -5695,7 +5695,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 8.6.0_eslint@7.32.0
-      prettier: 2.8.4
+      prettier: 2.8.7
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -5756,8 +5756,8 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-turbo/0.0.8_eslint@7.32.0:
-    resolution: {integrity: sha512-pExSCmjWw/KFKb3/0PVqxiWb30FbcwDEf6kKv3alvNBSVEzDHalyAGHc9klbLSG+nFmbkfNE3Ky/UHDryCqt8g==}
+  /eslint-plugin-turbo/1.8.6_eslint@7.32.0:
+    resolution: {integrity: sha512-LieXzur+4XtIsLst8GdupTMhvGn2ebFetG3AVErh2jHBy1EobPHbatjcdNZQMy5EsdG35axQVB8KFF3jo4u+OQ==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -7150,34 +7150,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.3.1_2263m44mchjafa7bz7l52hbcpa:
-    resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.3.1_ts-node@10.9.1
-      '@jest/test-result': 29.3.1
-      '@jest/types': 29.4.0
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 29.3.1_2263m44mchjafa7bz7l52hbcpa
-      jest-util: 29.4.0
-      jest-validate: 29.3.1
-      prompts: 2.4.2
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-cli/29.3.1_@types+node@17.0.45:
     resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7232,46 +7204,6 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config/29.3.1_2263m44mchjafa7bz7l52hbcpa:
-    resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.4.0
-      '@types/node': 17.0.45
-      babel-jest: 29.3.1_@babel+core@7.20.12
-      chalk: 4.1.2
-      ci-info: 3.7.1
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 29.3.1
-      jest-environment-node: 29.3.1
-      jest-get-type: 29.2.0
-      jest-regex-util: 29.2.0
-      jest-resolve: 29.3.1
-      jest-runner: 29.3.1
-      jest-util: 29.4.0
-      jest-validate: 29.3.1
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.4.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1_cin3sed6ohfsopbmt6orxeb4o4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-config/29.3.1_@types+node@17.0.45:
@@ -7721,26 +7653,6 @@ packages:
       jest-util: 29.4.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest/29.3.1_2263m44mchjafa7bz7l52hbcpa:
-    resolution: {integrity: sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.3.1_ts-node@10.9.1
-      '@jest/types': 29.4.0
-      import-local: 3.1.0
-      jest-cli: 29.3.1_2263m44mchjafa7bz7l52hbcpa
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
     dev: true
 
   /jest/29.3.1_@types+node@17.0.45:
@@ -8915,8 +8827,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier/2.8.4:
-    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
+  /prettier/2.8.7:
+    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -10196,37 +10108,6 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.18
-      acorn: 8.8.1
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node/10.9.1_cin3sed6ohfsopbmt6orxeb4o4:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 17.0.45
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
## What did you do
- add ```GET /users/:userId/history``` for casting to view actor's work history or for users to view their own's work history

## Demo
# Scenario 1 -> casting view actor's work history 
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login as any casting
- https://api-dev.modela.miello.dev/swagger#/users/UserController_getUsersWorkHistory
- get any actor's work history (userId from 11 to 20)
- should see all actor's work history that not refunded

# Scenario 2 -> users to view their own's work history
- https://api-dev.modela.miello.dev/swagger#/auth/AuthController_login
- login as any actor or casting
- https://api-dev.modela.miello.dev/swagger#/users/UserController_getUsersWorkHistory
- get their own's work history (actor 11 to 20, casting 21 to 30)

# Note
- work history is only JobStatus FINISHED and ApplicationStatus OFFER_ACCEPTED
- the job available might few, try inspect database inorder to check

## Limitation
- not have unit test yet
- didn't check for casting and only viewed actor that applied to their job
- didn't filter out jobs in casting view that refunded all actor applications (still return them)
