### PR TITLE
[EX] Fix missing status field in get application by job id

### DIFF
--- a/apps/api/src/modules/job/application/application.repository.ts
+++ b/apps/api/src/modules/job/application/application.repository.ts
@@ -61,6 +61,7 @@ export class ApplicationRepository {
         ...rest,
         ...User,
         ...Resume,
+        status,
         rating: jobStatus === JobStatus.FINISHED ? rating : undefined,
         isRefundable: !Refund && status === ApplicationStatus.OFFER_ACCEPTED,
       }),


### PR DESCRIPTION
## What did you do

<!--## For frontend please also paste the image of the part that you worked on-->

- Bring back missing `status` field

## Demo

<!--## Link to the page / API that you did in dev environment-->

- https://api-dev.modela.miello.dev/swagger#/application/ApplicationController_findByJobId
